### PR TITLE
Spoketree ticker

### DIFF
--- a/Docs/Core/00_MentalModel.md
+++ b/Docs/Core/00_MentalModel.md
@@ -44,7 +44,7 @@ In all of Spoke's code examples you'll see a lot of nested lambdas, which result
 Let's look at a simple Spoke program:
 
 ```cs
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect("Root", s => {
     s.Effect("1", s => {
         s.Effect("11", s => {
             s.Effect("111", s => { });
@@ -69,7 +69,7 @@ Which constructs the tree structure:
 ```
 (Tree Structure)            (Execution Order)
 
-FlushEngine                 1
+SpokeTree                   1
 │
 Root                        2
 ├── 1                       3
@@ -84,14 +84,14 @@ Root                        2
         └── 221             12
 ```
 
-First notice that the `FlushEngine` is an active object in the tree. When nodes attach to the tree, they find the nearest ancestor extending `SpokeEngine`, and schedule themselves there. The engine decides the tempo of execution. `FlushEngine` will always flush eagerly, executing all scheduled nodes in one synchronous flush. But other implementations are possible, like eagerly executing nodes up to a frame budget, or running nodes on a separate thread.
+First notice that the `SpokeTree` is an active object in the tree. When epochs attach to the tree, they find the nearest ancestor extending `Ticker`, and schedule themselves there. The ticker decides the tempo of execution. `SpokeTree` is one kind of ticker. In this configuration it will flush eagerly, ticking all scheduled epochs in one synchronous flush.
 
-The second column shows the order the nodes are flushed. It's in a strict imperative order. They're flushed in the same order as their code is written. This is **the most important invariant of the mental model**. The call-tree doesn't just encode ownership, it encodes causality as well. For a node to exist in the tree, all its older siblings must exist too. Even subclasses of `SpokeEngine` cannot break this invariant.
+The second column shows the order the epochs are ticked. It's in a strict imperative order. They're flushed in the same order as their code is written. This is **the most important invariant of the mental model**. The call-tree doesn't just encode ownership, it encodes causality as well. For an epoch to exist in the tree, all its earlier siblings must exist too. Even subclasses of `Ticker` cannot break this invariant.
 
-This invariant is vital for predictable execution behaviour when arbitrary subtrees are scheduled for remount. For example lets say a reactive signal triggers some of the effects to reschedule:
+This invariant is vital for predictable execution behaviour when arbitrary subtrees are scheduled for remount. For example lets say a reactive signal triggers some of the epochs to reschedule:
 
 ```
-FlushEngine
+SpokeTree
 │
 Root
 ├── 1
@@ -106,16 +106,16 @@ Root
         └── 221
 ```
 
-The nodes scheduled for remount are marked by a `*`, including `111`, `2` and `21`.
+The epochs scheduled for remount are marked by a `*`, including `111`, `2` and `21`.
 
-According to imperative ordering, they will execute in the order `111`, `2` and then `21`. Exactly the order they appear in the tree. In fact since `21` is descending from `2` it would remount anyway, so the fact it was explicitely scheduled makes no difference.
+According to imperative ordering, they will tick in the order `111`, `2` and then `21`. Exactly the order they appear in the tree. In fact since `21` is descending from `2` it would be recreated anyway, so the fact it was explicitely scheduled is ignored.
 
 The final execution order will be:
 
 ```
 (Tree Structure)            (Execution Order)
 
-FlushEngine
+SpokeTree
 │
 Root
 ├── 1
@@ -132,11 +132,11 @@ Root
 
 ---
 
-### Unmount behaviour
+### Detach behaviour
 
-When a live node is scheduled for re-execution, it will cause a remount. First the node is unmounted, and then mounted again fresh, rerunning the logic associated to that node.
+When a live epoch is scheduled to be ticked, it will cause a remount. First the epoch is detached, and then created again fresh, rerunning the logic associated to that node.
 
-When a node unmounts, it will first detach its children in reverse-imperative order. When node `2` was scheduled before, the nodes were cleaned up in this order:
+When an epoch detaches, it will first detach its children in reverse-imperative order. When node `2` was scheduled before, the epochs were cleaned up in this order:
 
 ```
 (Tree Structure)            (Cleanup Order)
@@ -158,16 +158,16 @@ After cleanup it results in the following transitory structure:
 └── 2
 ```
 
-Node `2` still exists in the tree, it's still 'attached', but its been unmounted. All its descendants have been detached and disposed, and its cleanup functions have run (in reverse declaration order). Immediately after unmounting `2`, Spoke will mount it once again to produce a new subtree.
+Epoch `2` still exists in the tree, it's still 'attached', but its been unmounted. All its descendants have been detached and disposed, and its cleanup functions have run (in reverse declaration order). Immediately after unmounting `2`, Spoke will mount it once again to produce a new subtree.
 
 ---
 
 ### Deferred Execution
 
-When a node is mounted, it attaches sub-nodes that are scheduled and mounted later. They're not mounted within the same call-stack frame. This has some subtle consequences to be aware of:
+When an epoch is mounted, it attaches sub-epochs that are scheduled and ticked later. They're not ticked within the same call-stack frame. This has some subtle consequences to be aware of:
 
 ```cs
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect("Root", s => {
 
     var number = 5;
     s.Effect(s => number = 10);
@@ -178,7 +178,7 @@ SpokeRuntime.SpawnTree(new FlushEngine(s => {
 }));
 ```
 
-Lets step through the construction of the call-tree to understand what's going on. First at the call to `engine.Effect(...)`:
+Lets step through the construction of the call-tree to understand what's going on. First at the call to `SpokeTree.Spawn(...)`:
 
 ```
 SpokeEngine
@@ -186,10 +186,10 @@ SpokeEngine
 Root*
 ```
 
-The Effect (named root) is attached to SpokeEngine. It's scheduled for mount, triggering a flush, but it's not mounted yet.
+The Effect (named root) is attached to SpokeTree. It's scheduled for tick, triggering a flush, but it's not mounted yet.
 
 ```
-SpokeEngine
+SpokeTree
 │
 Root            (number=5, print: "number is 5")
 ├── Effect*
@@ -200,7 +200,7 @@ Root            (number=5, print: "number is 5")
 Now root is mounted, and its mount function is called. It initializes `number = 5`, it attaches two sub-effects, and it prints `number is 5`. The first Effect will set `number = 10`, but only when it mounts. It's not mounted yet, it's attached and scheduled for mounting.
 
 ```
-SpokeEngine
+SpokeTree
 │
 Root
 ├── Effect      (number=10)
@@ -211,7 +211,7 @@ Root
 The first Effect is mounted and sets `number = 10`.
 
 ```
-SpokeEngine
+SpokeTree
 │
 Root
 ├── Effect
@@ -227,15 +227,13 @@ This behaviour can take you by surprise if you're not expecting it. But there's 
 
 `Spoke.Runtime.cs` defines a handful of base classes that implement the tree execution model:
 
-- `Node`: Is a runtime container for a mounted `Epoch` that forms the structure of the lifecycle tree. They're managed automatically by Spoke so you would rarely interact with them directly. Nodes form the fabric of the tree.
+- `Epoch`: Is the foundational base class in Spoke. Epochs are invoked declaratively, form a tree, and persist as active objects. They maintain state, respond to context, expose behaviour, and may spawn child epochs.
 
-- `Epoch`: Is the foundational base class in Spoke. Epochs are invoked declaratively, mounted into nodes, and persist as active objects. They maintain state, respond to context, expose behaviour, and may spawn child epochs.
+- `Ticker`: Is a type of `Epoch`, and an abstract class for controlling the tempo of execution of its subtree. When Epochs are attached to the tree, they schedule themselves on their contextual ticker to be ticked.
 
-- `SpokeEngine`: Is a type of `Epoch`, and an abstract class for controlling the tempo of execution of its subtree. When Epochs are attached to the tree, they schedule themselves on their contextual engine to be mounted.
+- `Dock`: An `Epoch` that lets you dynamically attach and dispose epochs at runtime.
 
-- `Dock`: An `Epoch` that lets you dynamically attach and dispose subtrees at runtime.
-
-This engine is the foundation that all the `Spoke.Reactive` behaviour is built on. Many of the reactive objects including `Effect`, `Reaction`, `Phase` and `Memo` are each derived from `Epoch`.
+This runtime is the foundation that all the `Spoke.Reactive` behaviour is built on. Many of the reactive objects including `Effect`, `Reaction`, `Phase` and `Memo` are each derived from `Epoch`.
 
 ---
 
@@ -274,7 +272,7 @@ public class MyCustomEpoch : Epoch {
 You can attach the custom epoch into the call-tree by 'calling' it from a parent epoch:
 
 ```cs
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect("Root", s => {
     var myEpoch = s.Call(new MyCustomeEpoch()); // Attaches to the tree and returns the epoch instance
     Debug.Log(myEpoch.IsAttached);              // Prints: true
 }));
@@ -283,11 +281,11 @@ SpokeRuntime.SpawnTree(new FlushEngine(s => {
 This would result in the following tree structure:
 
 ```
-Node[SpokeEngine]
+Epoch[SpokeEngine]
 │
-Node[Effect(name = "Root")]
+Epoch[Effect(name = "Root")]
 │
-Node[MyCustomEpoch(name = "My Epoch")]
+Epoch[MyCustomEpoch(name = "My Epoch")]
 ```
 
 Note the `s.Call()` expression. This is the fundamental way for epochs to be 'called' into the lifecycle tree. In `Spoke.Reactive` calls like `s.Effect()` and `s.Memo()` are convenience sugar over `s.Call()`:

--- a/Docs/Core/03_Effect.md
+++ b/Docs/Core/03_Effect.md
@@ -50,9 +50,8 @@ You can create effects yourself without having to use `SpokeBehaviour`:
 // A reactive state we can test with
 var number = State.Create(0);
 
-// Spawn a `SpokeTree` by invoking the `SpokeRuntime`. The root epoch should be an engine. The `FlushEngine`
-// is built for reactivity.
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+// Spawns a `SpokeTree`. The parameter is a subclass of Epoch thats attached under SpokeTree
+SpokeTree.Spawn(new Effect("Init", s => {
     s.Effect(s => {
         Debug.Log($"number is: {s.D(number)}");
     });
@@ -80,7 +79,7 @@ There are pros and cons to each. You can choose one or the other, or both, depen
 var myTrigger = Trigger.Create();
 var myState = State.Create(0);
 
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect(s => {
     s.Effect(s => {
         Debug.Log($"myState is {myState.Now}");
     }, myTrigger, myState); // any number of dependencies in final args
@@ -109,7 +108,7 @@ Dynamic dependencies are defined by calling a method from the `EffectBuilder`:
 var name = State.Create("Spokey");
 var age = State.Create(0);
 
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect(s => {
     s.Effect(s => {
         Debug.Log($"name: {s.D(name)}, age: {s.D(age)}");
     });
@@ -126,7 +125,7 @@ age.Set(1);         // Prints: name: Reacts, age 1
 If the `Effect` remounts, it will clear its dynamic dependencies, and then discover dependencies again on its next run. Dynamic dependencies can change on each run.
 
 ```csharp
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect(s => {
     s.Effect(s => {
         // Totally fine
         if (s.D(condition)) {

--- a/Docs/Core/05_FlushEngine.md
+++ b/Docs/Core/05_FlushEngine.md
@@ -1,30 +1,30 @@
-# FlushEngine
+# SpokeTree
 
-The `FlushEngine` is an implementation of `SpokeEngine`, whose behaviour is described in detail here: [Tree-Based Execution](./00_MentalModel.md#tree-based-execution). Therefore this page will only cover `FlushEngine` specific behaviour that's not part of the base `SpokeEngine`.
+The `SpokeTree` is an implementation of `Ticker`, whose behaviour is described in detail here: [Tree-Based Execution](./00_MentalModel.md#tree-based-execution). Therefore this page will only cover `SpokeTree` specific behaviour that's not already covered.
 
-When epochs are attached to a call-tree, they schedule themselves on the nearest `SpokeEngine`. Unless you're hacking deep in Spoke, this will be a `FlushEngine`, and it will be hosted by the root node of the tree.
+When epochs are attached to a call-tree, they schedule themselves on the nearest `Ticker`. Unless you're hacking deep in Spoke, this will be a `SpokeTree`, and it will be the root of the tree.
 
-When the engine begins a flush, it will synchronously execute all scheduled epochs until nothing remains to be done. The engine can be configured to flush immediately when an epoch is scheduled, or it can be controlled manually.
+When the SpokeTree begins a flush, it will synchronously execute all scheduled epochs until nothing remains to be done. The SpokeTree can be configured to flush immediately when an epoch is scheduled, or it can be controlled manually.
 
 ---
 
 ## Usage with SpokeBehaviour
 
-Each `SpokeBehaviour` creates it's own personal `FlushEngine`, that it mounts the `Init` Effect to. This default engine is configured with `FlushMode.Immediate`.
+Each `SpokeBehaviour` creates it's own personal `SpokeTree`, that it mounts the `Init` Effect to. This default SpokeTree is configured with `FlushMode.Auto`.
 
 ---
 
 ## Batching
 
-_Batching_ means grouping multiple reactive updates together before the `FlushEngine` flushes any computations.
-Put simply, batching tells the engine: **"Don't flush yet."**
+_Batching_ means grouping multiple reactive updates together before the `SpokeTree` flushes any computations.
+Put simply, batching tells the runtime: **"Don't flush yet."**
 
 In Spoke, batching happens in two ways:
 
-1. **Explicit Batching** – You call `FlushEngine.Batch(() => { ... })` to group updates manually.
-2. **Internal Deferral** – The engine automatically defers flushing during certain internal operations (like `Trigger.Invoke`) to ensure safety and consistency.
+1. **Explicit Batching** – You call `SpokeRuntime.Batch(() => { ... })` to group updates manually.
+2. **Internal Deferral** – The runtime automatically defers flushing during certain internal operations (like `Trigger.Invoke`) to ensure safety and consistency.
 
-Both mechanisms cause the engine to **defer a flush**.
+Both mechanisms cause the runtime to **defer a flush**.
 Both are essential for keeping your logic efficient and deterministic.
 
 Let's break them down.
@@ -39,7 +39,7 @@ First let's see the problem it's trying to solve:
 var className = State.Create("Warrior");
 var level = State.Create(1);
 
-SpokeRuntime.SpawnTree(new FlushEngine(s => {
+SpokeTree.Spawn(new Effect(s => {
     s.Effect(s => {
         Debug.Log($"class: {s.D(className)}, lvl: {s.D(level)}");
     });

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ public class MyBehaviour : SpokeBehaviour {
 
 ## ⚙️ Prefer manual control?
 
-You can also create a `FlushEngine` manually in any `MonoBehaviour`:
+You can also create a `SpokeTree` manually in any `MonoBehaviour`:
 
 ```csharp
 using Spoke;
@@ -131,11 +131,11 @@ using Spoke;
 public class MyBehaviour : MonoBehaviour {
 
     State<bool> isEnabled = State.Create(false);
-    SpokeTree<FlushEngine> tree;
+    SpokeTree tree;
 
     void Awake() {
-        // A FlushEngine is the execution scheduler for the reactive objects it contains
-        tree = SpokeRuntime.SpawnTree(new FlushEngine(s => {
+        // A SpokeTree is the root that drives execution of a reactive tree
+        tree = SpokeTree.Spawn(new Effect("Init", s => {
             s.Phase(isEnabled, s => {
                 // OnEnable logic
                 s.OnCleanup(() => {

--- a/Spoke.Reactive.cs
+++ b/Spoke.Reactive.cs
@@ -17,7 +17,7 @@ using System.Collections.Generic;
 namespace Spoke {
 
     public delegate void EffectBlock(EffectBuilder s);
-    public delegate Ref<T> EffectBlock<T>(EffectBuilder s);
+    public delegate IRef<T> EffectBlock<T>(EffectBuilder s);
     public delegate T MemoBlock<T>(MemoBuilder s);
 
     // ============================== Trigger ============================================================
@@ -94,10 +94,10 @@ namespace Spoke {
         }
     }
     // ============================== State ============================================================
-    public interface Ref<out T> {
+    public interface IRef<out T> {
         T Now { get; }
     }
-    public interface ISignal<out T> : Ref<T>, ITrigger<T> { }
+    public interface ISignal<out T> : IRef<T>, ITrigger<T> { }
     public interface IState<T> : ISignal<T> {
         void Set(T value);
         void Update(Func<T, T> setter);

--- a/Spoke.Reactive.cs
+++ b/Spoke.Reactive.cs
@@ -260,7 +260,7 @@ namespace Spoke {
     }
     // ============================== FlushEngine ============================================================
     public enum FlushMode { Immediate, Manual }
-    public class FlushEngine : SpokeEngine {
+    public class FlushEngine : Ticker {
         public FlushMode FlushMode = FlushMode.Immediate;
         Action flushCommand;
         Epoch epoch;
@@ -272,7 +272,7 @@ namespace Spoke {
         public FlushEngine(string name, EffectBlock block, FlushMode flushMode = FlushMode.Immediate) : this(name, new Effect("Root", block), flushMode) { }
         public FlushEngine(string name, FlushMode flushMode = FlushMode.Immediate) : this(name, (Epoch)null, flushMode) { }
         public FlushEngine(EffectBlock block, FlushMode flushMode = FlushMode.Immediate) : this("FlushEngine", block, flushMode) { }
-        protected override Epoch Bootstrap(EngineBuilder s) {
+        protected override Epoch Bootstrap(TickerBuilder s) {
             if (!s.TryImport(out ISpokeLogger logger)) logger = SpokeError.DefaultLogger;
             flushCommand = () => s.RequestTick();
             var isStopped = false;

--- a/Spoke.Runtime.cs
+++ b/Spoke.Runtime.cs
@@ -448,7 +448,9 @@ namespace Spoke {
             public Frame(FrameKind type, Epoch epoch) { Type = type; Epoch = epoch; }
             public override string ToString() {
                 if (Type == FrameKind.None) return "<null>";
-                return $"{Type} {Epoch} <{Epoch.GetType().Name}>{(Epoch.Fault != null ? $"[Faulted: {Epoch.Fault.InnerException.GetType().Name}]" : "")}";
+                var typeName = Epoch.GetType().Name;
+                typeName = typeName.IndexOf('`') >= 0 ? Epoch.GetType().Name.Substring(0, typeName.IndexOf('`')) : Epoch.GetType().Name;
+                return $"{Type} {Epoch} <{typeName}>{(Epoch.Fault != null ? $"[Faulted: {Epoch.Fault.InnerException.GetType().Name}]" : "")}";
             }
         }
         internal readonly struct Handle {

--- a/Spoke.Runtime.cs
+++ b/Spoke.Runtime.cs
@@ -415,7 +415,6 @@ namespace Spoke {
             onPopSelfFrames.RemoveAt(onPopSelfFrames.Count - 1);
             foreach (var fn in onPopSelf) fn?.Invoke();
             fnlPool.Return(onPopSelf);
-            if (frames.Count == 0) TryFlush();
         }
         void Friend.Hold() => holdCount++;
         void Friend.Release() { holdCount--; if (holdCount == 0) TryFlush(); }
@@ -438,6 +437,7 @@ namespace Spoke {
             var storeLayer = layer; layer = Math.Min((int)tree.FlushPolicy, layer);
             try { (tree as Epoch.Friend).Tick(); } catch (Exception e) { SpokeError.Log($"Uncaught Spoke error", e); }
             layer = storeLayer;
+            if (frames.Count == 0) TryFlush();
         }
         public enum FrameKind : byte { None, Init, Tick, Dock, Bootstrap }
         public readonly struct Frame {

--- a/Spoke.Unity.cs
+++ b/Spoke.Unity.cs
@@ -80,7 +80,7 @@ namespace Spoke {
             isStarted.Set(true);
         }
         void DoInit() {
-            root = SpokeTree.Spawn(new FlushEngine($"{GetType().Name}:FlushEngine", Init, FlushMode.Immediate), new UnitySpokeLogger(this));
+            root = SpokeTree.Spawn("Tree", new FlushEngine($"{GetType().Name}:FlushEngine", Init, FlushMode.Immediate), new UnitySpokeLogger(this));
             sceneTeardown = SpokeTeardown.Scene.Subscribe(scene => { if (scene == gameObject.scene) DoTeardown(); });
             appTeardown = SpokeTeardown.App.Subscribe(() => DoTeardown());
             isAwake.Set(true);

--- a/Spoke.Unity.cs
+++ b/Spoke.Unity.cs
@@ -61,7 +61,7 @@ namespace Spoke {
         public ISignal<bool> IsEnabled => isEnabled;
         public ISignal<bool> IsStarted => isStarted;
         SpokeHandle sceneTeardown, appTeardown;
-        SpokeTree<SpokeEngine> root;
+        SpokeTree root;
         protected abstract void Init(EffectBuilder s);
         protected virtual void Awake() {
             DoInit();
@@ -80,7 +80,7 @@ namespace Spoke {
             isStarted.Set(true);
         }
         void DoInit() {
-            root = SpokeRuntime.SpawnTree(new FlushEngine($"{GetType().Name}:FlushEngine", Init, FlushMode.Immediate), new UnitySpokeLogger(this));
+            root = SpokeTree.Spawn(new FlushEngine($"{GetType().Name}:FlushEngine", Init, FlushMode.Immediate), new UnitySpokeLogger(this));
             sceneTeardown = SpokeTeardown.Scene.Subscribe(scene => { if (scene == gameObject.scene) DoTeardown(); });
             appTeardown = SpokeTeardown.App.Subscribe(() => DoTeardown());
             isAwake.Set(true);

--- a/Spoke.Unity.cs
+++ b/Spoke.Unity.cs
@@ -80,7 +80,7 @@ namespace Spoke {
             isStarted.Set(true);
         }
         void DoInit() {
-            root = SpokeTree.Spawn("Tree", new FlushEngine($"{GetType().Name}:FlushEngine", Init, FlushMode.Immediate), new UnitySpokeLogger(this));
+            root = SpokeTree.Spawn($"{GetType().Name}:SpokeTree", new Effect("Init", Init), new UnitySpokeLogger(this));
             sceneTeardown = SpokeTeardown.Scene.Subscribe(scene => { if (scene == gameObject.scene) DoTeardown(); });
             appTeardown = SpokeTeardown.App.Subscribe(() => DoTeardown());
             isAwake.Set(true);


### PR DESCRIPTION
- Rename `SpokeEngine` to `Ticker`
- Turn `SpokeTree` into a `Ticker`
- Remove `FlushEngine` and give its powers to `SpokeTree`
- Manually flushed or ticked `SpokeTree` will occur synchronously. Or throw an exception on re-entrancy
- Fix a bug with `TreeCoords` for epochs that attach sub-epochs in Init