### PR TITLE
Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ Thumbs.db
 /Examples.meta
 /Docs.meta
 /Docs/**/*.meta
+
+# The hand-authored test project lives in the Unity-ignored Tests~ folder.
+# It is NOT an auto-generated csproj, so re-include it despite the *.csproj rule above.
+!/Tests~/Spoke.Tests.csproj

--- a/Spoke.Runtime/Dock.cs
+++ b/Spoke.Runtime/Dock.cs
@@ -40,7 +40,7 @@ namespace Spoke {
             }
             // Push a stack frame to reflect the docking action
             (SpokeRuntime.Local as SpokeRuntime.Friend).Push(new(SpokeRuntime.FrameKind.Dock, this));
-            Drop(key);  // Detach existing epoch at they key, if any
+            Drop(key);  // Detach existing epoch at the key, if any
             dynamicChildren.Add(key, epoch);
             // Monotonically increasing index ensures children ticks ordered by attach-time
             var childCoords = Coords.Extend(childIndex++);
@@ -56,7 +56,9 @@ namespace Spoke {
         /// </summary>
         public void Drop(object key) {
             if (!dynamicChildren.TryGetValue(key, out var child)) return;
-            (child as Epoch.Friend).Detach();
+            // If the child is mid-execution (dropping or re-keying itself), defer its detach until it
+            // finishes so its full teardown still runs; an idle child detaches immediately.
+            (child as Epoch.Friend).GetControlHandle().OnPopSelf((child as Epoch.Friend).Detach);
             dynamicChildren.Remove(key);
         }
 

--- a/Tests~/ReactiveTests/EffectTests.cs
+++ b/Tests~/ReactiveTests/EffectTests.cs
@@ -177,17 +177,24 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void EffectT_ExposesSignalAndUpdatesOnInnerStateChange() {
-            var inner = State.Create(1);
+        public void EffectT_ComposesInnerReactives_AndExposesDerivedSignal() {
+            var input = State.Create(1);
+            int output = 0;
 
-            var wrapper = new Effect<int>("w", s => inner);
-            using var tree = SpokeTree.SpawnManual(wrapper);
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                var derived = s.Effect(s => {
+                    var doubled = s.Memo(s => s.D(input) * 2);
+                    var plusOne = s.Memo(s => s.D(doubled) + 1);
+                    return plusOne;
+                });
+                s.Effect(s => output = s.D(derived));
+            }));
             tree.Flush();
-            Assert.AreEqual(1, wrapper.Now);
+            Assert.AreEqual(3, output);    // input 1 -> doubled 2 -> plusOne 3
 
-            inner.Set(42);
+            input.Set(5);
             tree.Flush();
-            Assert.AreEqual(42, wrapper.Now);
+            Assert.AreEqual(11, output);   // input 5 -> doubled 10 -> plusOne 11
         }
 
         [Test]

--- a/Tests~/ReactiveTests/EffectTests.cs
+++ b/Tests~/ReactiveTests/EffectTests.cs
@@ -1,0 +1,290 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class EffectTests : SpokeTestFixture {
+
+        [Test]
+        public void Effect_RunsOnMount() {
+            var runs = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("test", s => runs++));
+            tree.Flush();
+
+            Assert.AreEqual(1, runs);
+        }
+
+        [Test]
+        public void Effect_ReRuns_WhenDynamicDependencyChanges() {
+            var state = State.Create(0);
+            var runs = 0;
+            var lastSeen = -1;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("test", s => {
+                runs++;
+                lastSeen = s.D(state);
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, runs);
+            Assert.AreEqual(0, lastSeen);
+
+            state.Set(7);
+            tree.Flush();
+            Assert.AreEqual(2, runs);
+            Assert.AreEqual(7, lastSeen);
+        }
+
+        [Test]
+        public void Effect_Cleanup_RunsBeforeRerun() {
+            var state = State.Create(0);
+            var log = new List<string>();
+
+            using var tree = SpokeTree.SpawnManual(new Effect("test", s => {
+                var v = s.D(state);
+                log.Add($"mount:{v}");
+                s.OnCleanup(() => log.Add($"cleanup:{v}"));
+            }));
+            tree.Flush();
+
+            state.Set(1);
+            tree.Flush();
+
+            CollectionAssert.AreEqual(new[] { "mount:0", "cleanup:0", "mount:1" }, log);
+        }
+
+        [Test]
+        public void Effect_StaticTrigger_ReRunsOnFire() {
+            var trigger = Trigger.Create();
+            var runs = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("t", s => runs++, trigger));
+            tree.Flush();
+            Assert.AreEqual(1, runs);
+
+            trigger.Invoke();
+            tree.Flush();
+            Assert.AreEqual(2, runs);
+
+            trigger.Invoke();
+            tree.Flush();
+            Assert.AreEqual(3, runs);
+        }
+
+        [Test]
+        public void Effect_DynamicDependencies_DroppedTriggerNoLongerReRuns() {
+            var gate = State.Create(true);
+            var extra = State.Create(0);
+            var runs = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("dyn", s => {
+                runs++;
+                if (s.D(gate)) {
+                    _ = s.D(extra);
+                }
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, runs);
+
+            extra.Set(1);
+            tree.Flush();
+            Assert.AreEqual(2, runs);
+
+            gate.Set(false);
+            tree.Flush();
+            Assert.AreEqual(3, runs);
+
+            extra.Set(2);
+            tree.Flush();
+            Assert.AreEqual(3, runs);
+
+            gate.Set(true);
+            tree.Flush();
+            Assert.AreEqual(4, runs);
+        }
+
+        [Test]
+        public void Effect_Rerun_DetachesPriorChildren() {
+            var state = State.Create(0);
+            var childCleanups = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("parent", s => {
+                _ = s.D(state);
+                s.Effect(s => {
+                    s.OnCleanup(() => childCleanups++);
+                });
+            }));
+            tree.Flush();
+            Assert.AreEqual(0, childCleanups);
+
+            state.Set(1);
+            tree.Flush();
+            Assert.AreEqual(1, childCleanups);
+
+            state.Set(2);
+            tree.Flush();
+            Assert.AreEqual(2, childCleanups);
+        }
+
+        [Test]
+        public void Effect_NestedEffects_RunInImperativeOrder() {
+            var state = State.Create(0);
+            var log = new List<string>();
+
+            // Two sibling effects, composed under a root Effect that wires them up once.
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                s.Effect(s => {
+                    log.Add($"O1:{s.D(state)}");
+                    s.OnCleanup(() => log.Add("O1clean"));
+                    s.Effect(s => {
+                        log.Add($"I1:{s.D(state)}");
+                        s.OnCleanup(() => log.Add("I1clean"));
+                    });
+                });
+                s.Effect(s => {
+                    log.Add($"O2:{s.D(state)}");
+                    s.OnCleanup(() => log.Add("O2clean"));
+                    s.Effect(s => {
+                        log.Add($"I2:{s.D(state)}");
+                        s.OnCleanup(() => log.Add("I2clean"));
+                    });
+                });
+            }));
+            tree.Flush();
+            CollectionAssert.AreEqual(new[] { "O1:0", "I1:0", "O2:0", "I2:0" }, log);
+
+            log.Clear();
+            state.Set(1);
+            tree.Flush();
+            CollectionAssert.AreEqual(
+                new[] { "I1clean", "O1clean", "O1:1", "I1:1", "I2clean", "O2clean", "O2:1", "I2:1" },
+                log);
+        }
+
+        [Test]
+        public void Effect_DeferredExecution_InnerSeesPostMutationValue() {
+            var observed = -1;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("outer", s => {
+                var n = 10;
+                s.Effect(s => observed = n);
+                n = 20;
+            }));
+            tree.Flush();
+
+            Assert.AreEqual(20, observed);
+        }
+
+        [Test]
+        public void EffectT_ExposesSignalAndUpdatesOnInnerStateChange() {
+            var inner = State.Create(1);
+
+            var wrapper = new Effect<int>("w", s => inner);
+            using var tree = SpokeTree.SpawnManual(wrapper);
+            tree.Flush();
+            Assert.AreEqual(1, wrapper.Now);
+
+            inner.Set(42);
+            tree.Flush();
+            Assert.AreEqual(42, wrapper.Now);
+        }
+
+        [Test]
+        public void Effect_RescheduledByLaterSibling_RerunsBeforeOtherPending() {
+            // Effects sort by tree-coord. If E2 (middle) writes a state E1 (earlier) depends on,
+            // E1's reschedule is inserted ahead of E3 (later, still on first-tick) in the SpokeTree's
+            // pending heap. So E1 re-runs BEFORE E3 ticks for the first time.
+            var log = new List<string>();
+            var x = State.Create(0);
+            var triggered = false;
+
+            // Three sibling effects, composed under a root Effect that wires them up once.
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                s.Effect(s => log.Add($"E1:{s.D(x)}"));
+                s.Effect(s => {
+                    log.Add("E2");
+                    if (!triggered) {
+                        triggered = true;
+                        x.Set(1);
+                    }
+                });
+                s.Effect(s => log.Add($"E3:{s.D(x)}"));
+            }));
+            tree.Flush();
+
+            CollectionAssert.AreEqual(
+                new[] { "E1:0", "E2", "E1:1", "E3:1" },
+                log,
+                "After E2 writes x, E1 must re-run before E3 ticks for the first time");
+        }
+
+        [Test]
+        public void Effect_SelfReschedules_UntilTerminationCondition() {
+            // A well-behaved self-loop: effect sets a state it depends on, terminating at a fixed point.
+            // Same-coord transitions don't increment the oscillation passCount (CompareTo == 0),
+            // so the tree doesn't fault.
+            var x = State.Create(0);
+
+            using var tree = SpokeTree.SpawnManual(new Effect("inc", s => {
+                var v = s.D(x);
+                if (v < 5) x.Set(v + 1);
+            }));
+            tree.Flush();
+
+            Assert.AreEqual(5, x.Now);
+            Assert.IsNull(tree.Fault, "Self-loop with termination must not fault the tree");
+        }
+
+        [Test]
+        public void Effect_CapturedBuilderOutsideMutationWindow_Throws() {
+            EffectBuilder captured = default;
+            var threw = false;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("e", s => {
+                captured = s;
+            }));
+            tree.Flush();
+
+            try {
+                captured.OnCleanup(() => { });
+            } catch (System.InvalidOperationException) {
+                threw = true;
+            }
+
+            Assert.IsTrue(threw, "Expected InvalidOperationException when using a sealed EffectBuilder");
+        }
+
+        [Test]
+        public void StaleDependency_FiredMidRerun_BeforeItIsReRead_IsSuppressed() {
+            // An effect subscribes to a signal at the point it reads it with s.D(...), and a signal only
+            // re-runs the effects that are subscribed to it at the moment it fires. Dependencies are
+            // re-established in read order on each run — so if an effect WRITES a signal earlier in its
+            // body than it READS it, then at the instant of the write the effect is not yet subscribed to
+            // that signal this run, and the write cannot trigger a re-run. The dependency only takes hold
+            // once the s.D(...) below the write runs.
+            //
+            // Below: the effect writes `b` before depending on it, so changing `a` causes exactly ONE
+            // re-run. If that write were (incorrectly) treated as a live dependency, `runs` would climb to
+            // 3 instead of 2.
+            var a = State.Create(0);
+            var b = State.Create(-1);
+            var runs = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Effect("stale", s => {
+                var av = s.D(a);   // subscribe to a
+                b.Set(av);         // write b — not subscribed to b yet this run, so this can't re-trigger us
+                _ = s.D(b);        // subscribe to b (happens after the write)
+                runs++;
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, runs, "sanity: exactly one run on mount");
+
+            a.Set(5);
+            tree.Flush();
+            Assert.AreEqual(2, runs,
+                "Changing 'a' must cause exactly ONE re-run. Writing 'b' mid-run — before re-reading it — " +
+                "must not schedule a redundant second re-run.");
+        }
+    }
+}

--- a/Tests~/ReactiveTests/EffectTests.cs
+++ b/Tests~/ReactiveTests/EffectTests.cs
@@ -10,8 +10,7 @@ namespace Spoke.Tests {
         public void Effect_RunsOnMount() {
             var runs = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("test", s => runs++));
-            tree.Flush();
+            using var tree = SpokeTree.Spawn(new Effect("test", s => runs++));
 
             Assert.AreEqual(1, runs);
         }
@@ -22,16 +21,14 @@ namespace Spoke.Tests {
             var runs = 0;
             var lastSeen = -1;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("test", s => {
+            using var tree = SpokeTree.Spawn(new Effect("test", s => {
                 runs++;
                 lastSeen = s.D(state);
             }));
-            tree.Flush();
             Assert.AreEqual(1, runs);
             Assert.AreEqual(0, lastSeen);
 
             state.Set(7);
-            tree.Flush();
             Assert.AreEqual(2, runs);
             Assert.AreEqual(7, lastSeen);
         }
@@ -41,15 +38,13 @@ namespace Spoke.Tests {
             var state = State.Create(0);
             var log = new List<string>();
 
-            using var tree = SpokeTree.SpawnManual(new Effect("test", s => {
+            using var tree = SpokeTree.Spawn(new Effect("test", s => {
                 var v = s.D(state);
                 log.Add($"mount:{v}");
                 s.OnCleanup(() => log.Add($"cleanup:{v}"));
             }));
-            tree.Flush();
 
             state.Set(1);
-            tree.Flush();
 
             CollectionAssert.AreEqual(new[] { "mount:0", "cleanup:0", "mount:1" }, log);
         }
@@ -59,16 +54,13 @@ namespace Spoke.Tests {
             var trigger = Trigger.Create();
             var runs = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("t", s => runs++, trigger));
-            tree.Flush();
+            using var tree = SpokeTree.Spawn(new Effect("t", s => runs++, trigger));
             Assert.AreEqual(1, runs);
 
             trigger.Invoke();
-            tree.Flush();
             Assert.AreEqual(2, runs);
 
             trigger.Invoke();
-            tree.Flush();
             Assert.AreEqual(3, runs);
         }
 
@@ -78,29 +70,24 @@ namespace Spoke.Tests {
             var extra = State.Create(0);
             var runs = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("dyn", s => {
+            using var tree = SpokeTree.Spawn(new Effect("dyn", s => {
                 runs++;
                 if (s.D(gate)) {
                     _ = s.D(extra);
                 }
             }));
-            tree.Flush();
             Assert.AreEqual(1, runs);
 
             extra.Set(1);
-            tree.Flush();
             Assert.AreEqual(2, runs);
 
             gate.Set(false);
-            tree.Flush();
             Assert.AreEqual(3, runs);
 
             extra.Set(2);
-            tree.Flush();
             Assert.AreEqual(3, runs);
 
             gate.Set(true);
-            tree.Flush();
             Assert.AreEqual(4, runs);
         }
 
@@ -109,21 +96,18 @@ namespace Spoke.Tests {
             var state = State.Create(0);
             var childCleanups = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("parent", s => {
+            using var tree = SpokeTree.Spawn(new Effect("parent", s => {
                 _ = s.D(state);
                 s.Effect(s => {
                     s.OnCleanup(() => childCleanups++);
                 });
             }));
-            tree.Flush();
             Assert.AreEqual(0, childCleanups);
 
             state.Set(1);
-            tree.Flush();
             Assert.AreEqual(1, childCleanups);
 
             state.Set(2);
-            tree.Flush();
             Assert.AreEqual(2, childCleanups);
         }
 
@@ -133,7 +117,7 @@ namespace Spoke.Tests {
             var log = new List<string>();
 
             // Two sibling effects, composed under a root Effect that wires them up once.
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 s.Effect(s => {
                     log.Add($"O1:{s.D(state)}");
                     s.OnCleanup(() => log.Add("O1clean"));
@@ -151,29 +135,26 @@ namespace Spoke.Tests {
                     });
                 });
             }));
-            tree.Flush();
             CollectionAssert.AreEqual(new[] { "O1:0", "I1:0", "O2:0", "I2:0" }, log);
 
             log.Clear();
             state.Set(1);
-            tree.Flush();
             CollectionAssert.AreEqual(
                 new[] { "I1clean", "O1clean", "O1:1", "I1:1", "I2clean", "O2clean", "O2:1", "I2:1" },
                 log);
         }
 
         [Test]
-        public void Effect_DeferredExecution_InnerSeesPostMutationValue() {
-            var observed = -1;
+        public void Effect_DeferredExecution_ChildRunsAfterTheAttachingBlock() {
+            var log = new List<string>();
 
-            using var tree = SpokeTree.SpawnManual(new Effect("outer", s => {
-                var n = 10;
-                s.Effect(s => observed = n);
-                n = 20;
+            using var tree = SpokeTree.Spawn(new Effect("outer", s => {
+                log.Add("outer:start");
+                s.Effect(s => log.Add("inner"));
+                log.Add("outer:end");
             }));
-            tree.Flush();
 
-            Assert.AreEqual(20, observed);
+            CollectionAssert.AreEqual(new[] { "outer:start", "outer:end", "inner" }, log);
         }
 
         [Test]
@@ -181,7 +162,7 @@ namespace Spoke.Tests {
             var input = State.Create(1);
             int output = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 var derived = s.Effect(s => {
                     var doubled = s.Memo(s => s.D(input) * 2);
                     var plusOne = s.Memo(s => s.D(doubled) + 1);
@@ -189,11 +170,9 @@ namespace Spoke.Tests {
                 });
                 s.Effect(s => output = s.D(derived));
             }));
-            tree.Flush();
             Assert.AreEqual(3, output);    // input 1 -> doubled 2 -> plusOne 3
 
             input.Set(5);
-            tree.Flush();
             Assert.AreEqual(11, output);   // input 5 -> doubled 10 -> plusOne 11
         }
 
@@ -207,7 +186,7 @@ namespace Spoke.Tests {
             var triggered = false;
 
             // Three sibling effects, composed under a root Effect that wires them up once.
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 s.Effect(s => log.Add($"E1:{s.D(x)}"));
                 s.Effect(s => {
                     log.Add("E2");
@@ -218,7 +197,6 @@ namespace Spoke.Tests {
                 });
                 s.Effect(s => log.Add($"E3:{s.D(x)}"));
             }));
-            tree.Flush();
 
             CollectionAssert.AreEqual(
                 new[] { "E1:0", "E2", "E1:1", "E3:1" },
@@ -227,20 +205,20 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void Effect_SelfReschedules_UntilTerminationCondition() {
-            // A well-behaved self-loop: effect sets a state it depends on, terminating at a fixed point.
-            // Same-coord transitions don't increment the oscillation passCount (CompareTo == 0),
-            // so the tree doesn't fault.
+        public void Effect_SelfReschedules_WhenItWritesAStateItReads() {
+            // An effect that writes a state it also reads re-runs itself. Here it increments x each
+            // run until x reaches 5, then stops writing — converging to a fixed point.
             var x = State.Create(0);
+            var runs = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("inc", s => {
+            using var tree = SpokeTree.Spawn(new Effect("inc", s => {
+                runs++;
                 var v = s.D(x);
                 if (v < 5) x.Set(v + 1);
             }));
-            tree.Flush();
 
-            Assert.AreEqual(5, x.Now);
-            Assert.IsNull(tree.Fault, "Self-loop with termination must not fault the tree");
+            Assert.AreEqual(5, x.Now, "x converges to the fixed point");
+            Assert.AreEqual(6, runs, "the effect re-ran itself once per value 0..5");
         }
 
         [Test]
@@ -248,10 +226,9 @@ namespace Spoke.Tests {
             EffectBuilder captured = default;
             var threw = false;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("e", s => {
+            using var tree = SpokeTree.Spawn(new Effect("e", s => {
                 captured = s;
             }));
-            tree.Flush();
 
             try {
                 captured.OnCleanup(() => { });
@@ -278,17 +255,15 @@ namespace Spoke.Tests {
             var b = State.Create(-1);
             var runs = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("stale", s => {
+            using var tree = SpokeTree.Spawn(new Effect("stale", s => {
                 var av = s.D(a);   // subscribe to a
                 b.Set(av);         // write b — not subscribed to b yet this run, so this can't re-trigger us
                 _ = s.D(b);        // subscribe to b (happens after the write)
                 runs++;
             }));
-            tree.Flush();
             Assert.AreEqual(1, runs, "sanity: exactly one run on mount");
 
             a.Set(5);
-            tree.Flush();
             Assert.AreEqual(2, runs,
                 "Changing 'a' must cause exactly ONE re-run. Writing 'b' mid-run — before re-reading it — " +
                 "must not schedule a redundant second re-run.");

--- a/Tests~/ReactiveTests/MemoTests.cs
+++ b/Tests~/ReactiveTests/MemoTests.cs
@@ -11,14 +11,12 @@ namespace Spoke.Tests {
             var src = State.Create(5);
             ISignal<int> doubled = null;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 doubled = s.Memo(s => s.D(src) * 2);
             }));
-            tree.Flush();
             Assert.AreEqual(10, doubled.Now);
 
             src.Set(7);
-            tree.Flush();
             Assert.AreEqual(14, doubled.Now);
         }
 
@@ -28,18 +26,15 @@ namespace Spoke.Tests {
             var b = State.Create(3);
             ISignal<int> sum = null;
 
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 sum = s.Memo(s => s.D(a) + s.D(b));
             }));
-            tree.Flush();
             Assert.AreEqual(5, sum.Now);
 
             a.Set(10);
-            tree.Flush();
             Assert.AreEqual(13, sum.Now);
 
             b.Set(20);
-            tree.Flush();
             Assert.AreEqual(30, sum.Now);
         }
 
@@ -50,23 +45,20 @@ namespace Spoke.Tests {
             var dependentRuns = 0;
 
             // A Memo plus a dependent Effect, composed under a root Effect that wires them up once.
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 capped = s.Memo(s => System.Math.Min(s.D(input), 10));
                 s.Effect(s => {
                     dependentRuns++;
                     _ = s.D(capped);
                 });
             }));
-            tree.Flush();
             Assert.AreEqual(1, dependentRuns);
 
             input.Set(20);
-            tree.Flush();
             Assert.AreEqual(10, capped.Now);
             Assert.AreEqual(2, dependentRuns);
 
             input.Set(30);
-            tree.Flush();
             Assert.AreEqual(10, capped.Now);
             Assert.AreEqual(2, dependentRuns);
         }
@@ -76,7 +68,7 @@ namespace Spoke.Tests {
             var src = State.Create(0);
             var log = new List<string>();
 
-            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
                 s.Memo(s => {
                     var v = s.D(src);
                     log.Add($"compute:{v}");
@@ -84,10 +76,8 @@ namespace Spoke.Tests {
                     return v;
                 });
             }));
-            tree.Flush();
 
             src.Set(1);
-            tree.Flush();
 
             CollectionAssert.AreEqual(new[] { "compute:0", "cleanup:0", "compute:1" }, log);
         }
@@ -100,7 +90,7 @@ namespace Spoke.Tests {
             var log = new List<string>();
             var src = State.Create(0);
 
-            using var tree = SpokeTree.SpawnManual(new Effect("outer", s => {
+            using var tree = SpokeTree.Spawn(new Effect("outer", s => {
                 log.Add("outer");
                 var memo = s.Memo(s => {
                     log.Add($"memo:{s.D(src)}");
@@ -108,12 +98,10 @@ namespace Spoke.Tests {
                 });
                 s.Effect(s => log.Add($"inner:{s.D(memo)}"));
             }));
-            tree.Flush();
             CollectionAssert.AreEqual(new[] { "outer", "memo:0", "inner:0" }, log);
 
             log.Clear();
             src.Set(3);
-            tree.Flush();
             // memo ticks first (coord-sorted earlier), value changes 0 → 6, inner reruns
             CollectionAssert.AreEqual(new[] { "memo:3", "inner:6" }, log);
         }

--- a/Tests~/ReactiveTests/MemoTests.cs
+++ b/Tests~/ReactiveTests/MemoTests.cs
@@ -1,0 +1,115 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class MemoTests : SpokeTestFixture {
+
+        [Test]
+        public void Memo_Now_ReturnsComputedValue() {
+            var src = State.Create(5);
+
+            var doubled = new Memo<int>("d", s => s.D(src) * 2);
+            using var tree = SpokeTree.SpawnManual(doubled);
+            tree.Flush();
+            Assert.AreEqual(10, doubled.Now);
+
+            src.Set(7);
+            tree.Flush();
+            Assert.AreEqual(14, doubled.Now);
+        }
+
+        [Test]
+        public void Memo_RecomputesOnDependencyChange() {
+            var a = State.Create(2);
+            var b = State.Create(3);
+
+            var sum = new Memo<int>("sum", s => s.D(a) + s.D(b));
+            using var tree = SpokeTree.SpawnManual(sum);
+            tree.Flush();
+            Assert.AreEqual(5, sum.Now);
+
+            a.Set(10);
+            tree.Flush();
+            Assert.AreEqual(13, sum.Now);
+
+            b.Set(20);
+            tree.Flush();
+            Assert.AreEqual(30, sum.Now);
+        }
+
+        [Test]
+        public void Memo_SameComputedValue_DoesNotPropagate() {
+            var input = State.Create(1);
+            ISignal<int> capped = null;
+            var dependentRuns = 0;
+
+            // A Memo plus a dependent Effect, composed under a root Effect that wires them up once.
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                capped = s.Memo(s => System.Math.Min(s.D(input), 10));
+                s.Effect(s => {
+                    dependentRuns++;
+                    _ = s.D(capped);
+                });
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, dependentRuns);
+
+            input.Set(20);
+            tree.Flush();
+            Assert.AreEqual(10, capped.Now);
+            Assert.AreEqual(2, dependentRuns);
+
+            input.Set(30);
+            tree.Flush();
+            Assert.AreEqual(10, capped.Now);
+            Assert.AreEqual(2, dependentRuns);
+        }
+
+        [Test]
+        public void Memo_OnCleanup_RunsBeforeRerun() {
+            var src = State.Create(0);
+            var log = new List<string>();
+
+            using var tree = SpokeTree.SpawnManual(new Memo<int>("m", s => {
+                var v = s.D(src);
+                log.Add($"compute:{v}");
+                s.OnCleanup(() => log.Add($"cleanup:{v}"));
+                return v;
+            }));
+            tree.Flush();
+
+            src.Set(1);
+            tree.Flush();
+
+            CollectionAssert.AreEqual(new[] { "compute:0", "cleanup:0", "compute:1" }, log);
+        }
+
+        [Test]
+        public void Memo_AndInnerEffect_AttachedInOuterTick_TickInTreeCoordOrderAfterOuter() {
+            // Per the docs' "Deferred Execution" rule: nodes attached during a tick don't run inside
+            // that same tick — they're queued and ticked by the SpokeTree in tree-coord order after
+            // the outer tick returns. Within that order: Memo (attached first) ticks before Effect.
+            var log = new List<string>();
+            var src = State.Create(0);
+
+            using var tree = SpokeTree.SpawnManual(new Effect("outer", s => {
+                log.Add("outer");
+                var memo = s.Memo(s => {
+                    log.Add($"memo:{s.D(src)}");
+                    return s.D(src) * 2;
+                });
+                s.Effect(s => log.Add($"inner:{s.D(memo)}"));
+            }));
+            tree.Flush();
+            CollectionAssert.AreEqual(new[] { "outer", "memo:0", "inner:0" }, log);
+
+            log.Clear();
+            src.Set(3);
+            tree.Flush();
+            // memo ticks first (coord-sorted earlier), value changes 0 → 6, inner reruns
+            CollectionAssert.AreEqual(new[] { "memo:3", "inner:6" }, log);
+        }
+    }
+}

--- a/Tests~/ReactiveTests/MemoTests.cs
+++ b/Tests~/ReactiveTests/MemoTests.cs
@@ -9,9 +9,11 @@ namespace Spoke.Tests {
         [Test]
         public void Memo_Now_ReturnsComputedValue() {
             var src = State.Create(5);
+            ISignal<int> doubled = null;
 
-            var doubled = new Memo<int>("d", s => s.D(src) * 2);
-            using var tree = SpokeTree.SpawnManual(doubled);
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                doubled = s.Memo(s => s.D(src) * 2);
+            }));
             tree.Flush();
             Assert.AreEqual(10, doubled.Now);
 
@@ -24,9 +26,11 @@ namespace Spoke.Tests {
         public void Memo_RecomputesOnDependencyChange() {
             var a = State.Create(2);
             var b = State.Create(3);
+            ISignal<int> sum = null;
 
-            var sum = new Memo<int>("sum", s => s.D(a) + s.D(b));
-            using var tree = SpokeTree.SpawnManual(sum);
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                sum = s.Memo(s => s.D(a) + s.D(b));
+            }));
             tree.Flush();
             Assert.AreEqual(5, sum.Now);
 
@@ -72,11 +76,13 @@ namespace Spoke.Tests {
             var src = State.Create(0);
             var log = new List<string>();
 
-            using var tree = SpokeTree.SpawnManual(new Memo<int>("m", s => {
-                var v = s.D(src);
-                log.Add($"compute:{v}");
-                s.OnCleanup(() => log.Add($"cleanup:{v}"));
-                return v;
+            using var tree = SpokeTree.SpawnManual(new Effect("root", s => {
+                s.Memo(s => {
+                    var v = s.D(src);
+                    log.Add($"compute:{v}");
+                    s.OnCleanup(() => log.Add($"cleanup:{v}"));
+                    return v;
+                });
             }));
             tree.Flush();
 
@@ -87,10 +93,10 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void Memo_AndInnerEffect_AttachedInOuterTick_TickInTreeCoordOrderAfterOuter() {
-            // Per the docs' "Deferred Execution" rule: nodes attached during a tick don't run inside
-            // that same tick — they're queued and ticked by the SpokeTree in tree-coord order after
-            // the outer tick returns. Within that order: Memo (attached first) ticks before Effect.
+        public void Memo_Recompute_PropagatesToDependentEffect() {
+            // A Memo feeding a dependent Effect. On mount, both run after the outer that created them
+            // (deferred) and in tree-coord order (memo before effect). When src changes, the memo
+            // recomputes and the dependent effect re-runs with the new value.
             var log = new List<string>();
             var src = State.Create(0);
 

--- a/Tests~/ReactiveTests/PhaseTests.cs
+++ b/Tests~/ReactiveTests/PhaseTests.cs
@@ -1,0 +1,80 @@
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class PhaseTests : SpokeTestFixture {
+
+        [Test]
+        public void Phase_MountsAndUnmountsOnBoolFlip() {
+            var gate = State.Create(false);
+            var mounted = 0;
+            var cleaned = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Phase("p", gate, s => {
+                mounted++;
+                s.OnCleanup(() => cleaned++);
+            }));
+            tree.Flush();
+            Assert.AreEqual(0, mounted, "Phase should not mount while gate=false");
+
+            gate.Set(true);
+            tree.Flush();
+            Assert.AreEqual(1, mounted);
+            Assert.AreEqual(0, cleaned);
+
+            gate.Set(false);
+            tree.Flush();
+            Assert.AreEqual(1, mounted);
+            Assert.AreEqual(1, cleaned);
+
+            gate.Set(true);
+            tree.Flush();
+            Assert.AreEqual(2, mounted);
+            Assert.AreEqual(1, cleaned);
+        }
+
+        [Test]
+        public void Phase_ReRunsWhileMounted_WhenAdditionalTriggersFire() {
+            var gate = State.Create(true);
+            var pulse = Trigger.Create();
+            var runs = 0;
+            var cleanups = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Phase("p", gate, s => {
+                runs++;
+                s.OnCleanup(() => cleanups++);
+            }, pulse));
+            tree.Flush();
+            Assert.AreEqual(1, runs);
+
+            pulse.Invoke();
+            tree.Flush();
+            Assert.AreEqual(2, runs);
+            Assert.AreEqual(1, cleanups);
+
+            pulse.Invoke();
+            tree.Flush();
+            Assert.AreEqual(3, runs);
+            Assert.AreEqual(2, cleanups);
+        }
+
+        [Test]
+        public void Phase_AdditionalTriggers_DoNotMount_WhenGateIsFalse() {
+            var gate = State.Create(false);
+            var pulse = Trigger.Create();
+            var runs = 0;
+
+            using var tree = SpokeTree.SpawnManual(new Phase("p", gate, s => runs++, pulse));
+            tree.Flush();
+
+            pulse.Invoke();
+            tree.Flush();
+            Assert.AreEqual(0, runs, "Triggers should not cause Phase block to run while gate=false");
+
+            gate.Set(true);
+            tree.Flush();
+            Assert.AreEqual(1, runs);
+        }
+    }
+}

--- a/Tests~/ReactiveTests/PhaseTests.cs
+++ b/Tests~/ReactiveTests/PhaseTests.cs
@@ -11,25 +11,21 @@ namespace Spoke.Tests {
             var mounted = 0;
             var cleaned = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Phase("p", gate, s => {
+            using var tree = SpokeTree.Spawn(new Phase("p", gate, s => {
                 mounted++;
                 s.OnCleanup(() => cleaned++);
             }));
-            tree.Flush();
             Assert.AreEqual(0, mounted, "Phase should not mount while gate=false");
 
             gate.Set(true);
-            tree.Flush();
             Assert.AreEqual(1, mounted);
             Assert.AreEqual(0, cleaned);
 
             gate.Set(false);
-            tree.Flush();
             Assert.AreEqual(1, mounted);
             Assert.AreEqual(1, cleaned);
 
             gate.Set(true);
-            tree.Flush();
             Assert.AreEqual(2, mounted);
             Assert.AreEqual(1, cleaned);
         }
@@ -41,20 +37,17 @@ namespace Spoke.Tests {
             var runs = 0;
             var cleanups = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Phase("p", gate, s => {
+            using var tree = SpokeTree.Spawn(new Phase("p", gate, s => {
                 runs++;
                 s.OnCleanup(() => cleanups++);
             }, pulse));
-            tree.Flush();
             Assert.AreEqual(1, runs);
 
             pulse.Invoke();
-            tree.Flush();
             Assert.AreEqual(2, runs);
             Assert.AreEqual(1, cleanups);
 
             pulse.Invoke();
-            tree.Flush();
             Assert.AreEqual(3, runs);
             Assert.AreEqual(2, cleanups);
         }
@@ -65,15 +58,12 @@ namespace Spoke.Tests {
             var pulse = Trigger.Create();
             var runs = 0;
 
-            using var tree = SpokeTree.SpawnManual(new Phase("p", gate, s => runs++, pulse));
-            tree.Flush();
+            using var tree = SpokeTree.Spawn(new Phase("p", gate, s => runs++, pulse));
 
             pulse.Invoke();
-            tree.Flush();
             Assert.AreEqual(0, runs, "Triggers should not cause Phase block to run while gate=false");
 
             gate.Set(true);
-            tree.Flush();
             Assert.AreEqual(1, runs);
         }
     }

--- a/Tests~/ReactiveTests/ReactionTests.cs
+++ b/Tests~/ReactiveTests/ReactionTests.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class ReactionTests : SpokeTestFixture {
+
+        [Test]
+        public void Reaction_DoesNotRunOnInitialMount() {
+            var runs = 0;
+            var trigger = Trigger.Create();
+
+            using var tree = SpokeTree.SpawnManual(new Reaction("r", s => runs++, trigger));
+            tree.Flush();
+
+            Assert.AreEqual(0, runs, "Reaction should skip its initial mount");
+        }
+
+        [Test]
+        public void Reaction_RunsOnTriggerFire() {
+            var runs = 0;
+            var trigger = Trigger.Create();
+
+            using var tree = SpokeTree.SpawnManual(new Reaction("r", s => runs++, trigger));
+            tree.Flush();
+            Assert.AreEqual(0, runs);
+
+            trigger.Invoke();
+            tree.Flush();
+            Assert.AreEqual(1, runs);
+
+            trigger.Invoke();
+            tree.Flush();
+            Assert.AreEqual(2, runs);
+        }
+    }
+}

--- a/Tests~/ReactiveTests/ReactionTests.cs
+++ b/Tests~/ReactiveTests/ReactionTests.cs
@@ -10,8 +10,7 @@ namespace Spoke.Tests {
             var runs = 0;
             var trigger = Trigger.Create();
 
-            using var tree = SpokeTree.SpawnManual(new Reaction("r", s => runs++, trigger));
-            tree.Flush();
+            using var tree = SpokeTree.Spawn(new Reaction("r", s => runs++, trigger));
 
             Assert.AreEqual(0, runs, "Reaction should skip its initial mount");
         }
@@ -21,16 +20,13 @@ namespace Spoke.Tests {
             var runs = 0;
             var trigger = Trigger.Create();
 
-            using var tree = SpokeTree.SpawnManual(new Reaction("r", s => runs++, trigger));
-            tree.Flush();
+            using var tree = SpokeTree.Spawn(new Reaction("r", s => runs++, trigger));
             Assert.AreEqual(0, runs);
 
             trigger.Invoke();
-            tree.Flush();
             Assert.AreEqual(1, runs);
 
             trigger.Invoke();
-            tree.Flush();
             Assert.AreEqual(2, runs);
         }
     }

--- a/Tests~/ReactiveTests/StateTests.cs
+++ b/Tests~/ReactiveTests/StateTests.cs
@@ -1,0 +1,90 @@
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class StateTests : SpokeTestFixture {
+
+        [Test]
+        public void Set_SameValue_DoesNotNotify() {
+            var state = State.Create(1);
+            var calls = 0;
+            using var sub = state.Subscribe(() => calls++);
+
+            state.Set(1);
+
+            Assert.AreEqual(0, calls);
+        }
+
+        [Test]
+        public void Set_DifferentValue_Notifies() {
+            var state = State.Create(1);
+            var calls = 0;
+            using var sub = state.Subscribe(() => calls++);
+
+            state.Set(2);
+            state.Set(2);   // no change
+            state.Set(3);
+
+            Assert.AreEqual(2, calls);
+        }
+
+        [Test]
+        public void Update_AppliesSetterToCurrentValue() {
+            var state = State.Create(5);
+            var observed = 0;
+            using var sub = state.Subscribe((int v) => observed = v);
+
+            state.Update(x => x * 2);
+
+            Assert.AreEqual(10, state.Now);
+            Assert.AreEqual(10, observed);
+        }
+
+        [Test]
+        public void Update_NullSetter_IsNoOp() {
+            var state = State.Create(5);
+            var notified = false;
+            using var sub = state.Subscribe(() => notified = true);
+
+            state.Update(null);
+
+            Assert.AreEqual(5, state.Now);
+            Assert.IsFalse(notified);
+        }
+
+        [Test]
+        public void Set_SameReference_DoesNotNotify() {
+            var inst = new object();
+            var state = State.Create(inst);
+            var calls = 0;
+            using var sub = state.Subscribe(() => calls++);
+
+            state.Set(inst);
+
+            Assert.AreEqual(0, calls);
+        }
+
+        [Test]
+        public void Set_DifferentReference_Notifies() {
+            var state = State.Create(new object());
+            var calls = 0;
+            using var sub = state.Subscribe(() => calls++);
+
+            state.Set(new object());
+
+            Assert.AreEqual(1, calls);
+        }
+
+        [Test]
+        public void Set_NullToNull_DoesNotNotify() {
+            var state = State.Create<object>(null);
+            var calls = 0;
+            using var sub = state.Subscribe(() => calls++);
+
+            state.Set(null);
+
+            Assert.AreEqual(0, calls);
+        }
+    }
+}

--- a/Tests~/ReactiveTests/TriggerTests.cs
+++ b/Tests~/ReactiveTests/TriggerTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    [NonParallelizable]
+    public class TriggerTests : SpokeTestFixture {
+
+        [Test]
+        public void Trigger_FiresAllSubscribers() {
+            var trigger = Trigger.Create();
+            var a = 0;
+            var b = 0;
+
+            using var ha = trigger.Subscribe(() => a++);
+            using var hb = trigger.Subscribe(() => b++);
+
+            trigger.Invoke();
+            trigger.Invoke();
+
+            Assert.AreEqual(2, a);
+            Assert.AreEqual(2, b);
+        }
+
+        [Test]
+        public void Trigger_Unsubscribe_ByDisposeHandle_StopsFurtherInvocations() {
+            var trigger = Trigger.Create();
+            var count = 0;
+
+            var sub = trigger.Subscribe(() => count++);
+            trigger.Invoke();
+            sub.Dispose();
+            trigger.Invoke();
+
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void Trigger_Unsubscribe_ByAction_RemovesByDelegate() {
+            var trigger = Trigger.Create();
+            var count = 0;
+            Action handler = () => count++;
+
+            var _ = trigger.Subscribe(handler);
+            trigger.Invoke();
+            trigger.Unsubscribe(handler);
+            trigger.Invoke();
+
+            Assert.AreEqual(1, count);
+        }
+
+        [Test]
+        public void TriggerT_SubscribeWithPayload_ReceivesPayload() {
+            var t = Trigger.Create<int>();
+            var seen = -1;
+            using var sub = t.Subscribe((int v) => seen = v);
+
+            t.Invoke(42);
+            Assert.AreEqual(42, seen);
+        }
+
+        [Test]
+        public void TriggerT_SubscribeWithoutPayload_StillNotifiedOnPayloadInvoke() {
+            var t = Trigger.Create<int>();
+            var ran = false;
+            using var sub = t.Subscribe(() => ran = true);
+
+            t.Invoke(7);
+            Assert.IsTrue(ran);
+        }
+
+        [Test]
+        public void Trigger_ReentrantInvoke_IsQueued() {
+            var t = Trigger.Create<int>();
+            var seen = new List<int>();
+            var calls = 0;
+            using var sub = t.Subscribe((int v) => {
+                seen.Add(v);
+                calls++;
+                if (calls == 1) {
+                    t.Invoke(99);  // re-entrant
+                }
+            });
+
+            t.Invoke(1);
+            CollectionAssert.AreEqual(new[] { 1, 99 }, seen);
+        }
+
+        [Test]
+        public void Trigger_SubscriberException_IsSwallowed_OthersStillFire() {
+            Errors.ExpectErrors();
+            var t = Trigger.Create();
+            var second = false;
+            using var s1 = t.Subscribe(() => throw new Exception("boom"));
+            using var s2 = t.Subscribe(() => second = true);
+
+            t.Invoke();
+
+            Assert.IsTrue(second, "Second subscriber should still fire after first throws");
+            Assert.Greater(Errors.Entries.Count, 0);
+        }
+
+        [Test]
+        public void Trigger_SubscribeDuringInvoke_NotNotifiedThisRound() {
+            var t = Trigger.Create();
+            var calls = 0;
+            SpokeHandle lateSub = default;
+            using var sub = t.Subscribe(() => {
+                calls++;
+                if (calls == 1) {
+                    lateSub = t.Subscribe(() => calls++);
+                }
+            });
+
+            t.Invoke();  // Only the existing sub fires; lateSub added during invoke
+            Assert.AreEqual(1, calls);
+
+            t.Invoke();  // Now both fire
+            Assert.AreEqual(3, calls);
+            lateSub.Dispose();
+        }
+
+        [Test]
+        public void TriggerInvoke_BatchesStateMutations_NoIntermediateObservation() {
+            // The doc (02_Trigger.md §Batched Notifications) promises that a Trigger.Invoke
+            // wraps in SpokeRuntime.Batch. So state writes inside the subscriber should be
+            // batched — dependents see only the final combined state, never intermediate.
+            var t = Trigger.Create();
+            var v1 = State.Create(0);
+            var v2 = State.Create(0);
+            var observations = new List<int>();
+
+            using var tree = SpokeTree.Spawn(new Effect("init", s => {
+                s.Effect(s => observations.Add(s.D(v1) + s.D(v2)));
+                s.Subscribe(t, () => {
+                    v1.Set(10);
+                    v2.Set(20);
+                });
+            }));
+            CollectionAssert.AreEqual(new[] { 0 }, observations);
+
+            t.Invoke();
+
+            CollectionAssert.AreEqual(new[] { 0, 30 }, observations);
+        }
+    }
+}

--- a/Tests~/ReactiveTests/TriggerTests.cs
+++ b/Tests~/ReactiveTests/TriggerTests.cs
@@ -124,9 +124,9 @@ namespace Spoke.Tests {
 
         [Test]
         public void TriggerInvoke_BatchesStateMutations_NoIntermediateObservation() {
-            // The doc (02_Trigger.md §Batched Notifications) promises that a Trigger.Invoke
-            // wraps in SpokeRuntime.Batch. So state writes inside the subscriber should be
-            // batched — dependents see only the final combined state, never intermediate.
+            // A Trigger.Invoke batches the state mutations its subscribers make: a dependent effect
+            // observes only the final combined value (0 then 30), never an intermediate where v1 has
+            // updated but v2 has not.
             var t = Trigger.Create();
             var v1 = State.Create(0);
             var v2 = State.Create(0);

--- a/Tests~/RuntimeTests/DockTests.cs
+++ b/Tests~/RuntimeTests/DockTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class DockTests : SpokeTestFixture {
+
+        [Test]
+        public void Call_AttachesEpoch_AndRunsInit() {
+            var attached = false;
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("k", new LambdaEpoch(s => {
+                attached = true;
+                return null;
+            }));
+
+            Assert.IsTrue(attached);
+        }
+
+        [Test]
+        public void Call_OnExistingKey_FirstDetachesOldChild() {
+            var firstCleanup = false;
+            var secondAttached = false;
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("k", new LambdaEpoch(s => {
+                s.OnCleanup(() => firstCleanup = true);
+                return null;
+            }));
+            Assert.IsFalse(firstCleanup);
+
+            dock.Call("k", new LambdaEpoch(s => {
+                secondAttached = true;
+                return null;
+            }));
+
+            Assert.IsTrue(firstCleanup, "Old child at key should be detached first");
+            Assert.IsTrue(secondAttached);
+        }
+
+        [Test]
+        public void Drop_MissingKey_IsNoOp() {
+            Dock dock = null;
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            Assert.DoesNotThrow(() => dock.Drop("never-attached"));
+        }
+
+        [Test]
+        public void Drop_DetachesChild_AndRunsCleanup() {
+            var cleaned = false;
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("k", new LambdaEpoch(s => {
+                s.OnCleanup(() => cleaned = true);
+                return null;
+            }));
+
+            dock.Drop("k");
+            Assert.IsTrue(cleaned);
+        }
+
+        [Test]
+        public void DockCleanup_DetachesChildren_InReverseAttachOrder() {
+            var log = new List<string>();
+            Dock dock = null;
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("a", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("a")); return null; }));
+            dock.Call("b", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("b")); return null; }));
+            dock.Call("c", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("c")); return null; }));
+
+            tree.Dispose();
+
+            CollectionAssert.AreEqual(new[] { "c", "b", "a" }, log);
+        }
+
+        [Test]
+        public void CallWhileDetaching_Throws() {
+            Exception caught = null;
+
+            using (var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                var dock = s.Call(new Dock());
+                dock.Call("k", new LambdaEpoch(s => {
+                    s.OnCleanup(() => {
+                        try {
+                            dock.Call("late", new LambdaEpoch(s => null));
+                        } catch (Exception ex) {
+                            caught = ex;
+                        }
+                    });
+                    return null;
+                }));
+                return null;
+            }))) {
+                // Tree disposes here on scope exit
+            }
+
+            Assert.IsNotNull(caught, "Dock.Call during detaching should throw");
+        }
+    }
+}

--- a/Tests~/RuntimeTests/DockTests.cs
+++ b/Tests~/RuntimeTests/DockTests.cs
@@ -8,8 +8,9 @@ namespace Spoke.Tests {
     public class DockTests : SpokeTestFixture {
 
         [Test]
-        public void Call_AttachesEpoch_AndRunsInit() {
+        public void Call_AttachesEpoch() {
             var attached = false;
+            var ticked = false;
             Dock dock = null;
 
             using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
@@ -19,16 +20,41 @@ namespace Spoke.Tests {
 
             dock.Call("k", new LambdaEpoch(s => {
                 attached = true;
-                return null;
+                return s => {
+                    ticked = true;
+                };
             }));
 
             Assert.IsTrue(attached);
+            Assert.IsFalse(ticked);
+
+            tree.Flush();
+            Assert.IsTrue(ticked);
+        }
+
+        [Test]
+        public void Call_ChildrenTickInAttachOrder() {
+            var ticked = new List<string>();
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("x", new LambdaEpoch(s => s => ticked.Add("x")));
+            dock.Call("a", new LambdaEpoch(s => s => ticked.Add("a")));
+            dock.Call("m", new LambdaEpoch(s => s => ticked.Add("m")));
+
+            tree.Flush();
+
+            CollectionAssert.AreEqual(new[] { "x", "a", "m" }, ticked,
+                "Children tick in attach order");
         }
 
         [Test]
         public void Call_OnExistingKey_FirstDetachesOldChild() {
-            var firstCleanup = false;
-            var secondAttached = false;
+            var log = new List<string>();
             Dock dock = null;
 
             using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
@@ -37,18 +63,18 @@ namespace Spoke.Tests {
             }));
 
             dock.Call("k", new LambdaEpoch(s => {
-                s.OnCleanup(() => firstCleanup = true);
+                s.OnCleanup(() => log.Add("first-cleanup"));
                 return null;
             }));
-            Assert.IsFalse(firstCleanup);
 
             dock.Call("k", new LambdaEpoch(s => {
-                secondAttached = true;
+                log.Add("second-attached");
                 return null;
             }));
 
-            Assert.IsTrue(firstCleanup, "Old child at key should be detached first");
-            Assert.IsTrue(secondAttached);
+            CollectionAssert.AreEqual(
+                new[] { "first-cleanup", "second-attached" },
+                log);
         }
 
         [Test]
@@ -82,6 +108,55 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void Drop_SelfDuringAttach_RunsCleanup_AndDoesNotTick() {
+            var log = new List<string>();
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("k", new LambdaEpoch(s => {
+                dock.Drop("k");              // drop self while still attaching
+                s.OnCleanup(() => log.Add("cleanup"));
+                return s => log.Add("tick");
+            }));
+
+            tree.Flush();
+
+            Assert.IsNull(tree.Fault);
+            CollectionAssert.AreEqual(new[] { "cleanup" }, log,
+                "the self-dropped epoch runs its cleanup and never ticks");
+        }
+
+        [Test]
+        public void Call_SameKeyDuringOwnAttach_ReplacesSelf() {
+            var log = new List<string>();
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            dock.Call("k", new LambdaEpoch(s => {
+                s.OnCleanup(() => log.Add("old-cleanup"));
+                dock.Call("k", new LambdaEpoch(s => {   // re-key self with the same key
+                    log.Add("new-attached");
+                    return s => log.Add("new-tick");
+                }));
+                return s => log.Add("old-tick");
+            }));
+
+            tree.Flush();
+
+            CollectionAssert.AreEqual(new[] { "new-attached", "old-cleanup", "new-tick" }, log,
+                "replacement attaches, then the old epoch cleans up once it finishes; the old never ticks");
+            Assert.IsNull(tree.Fault);
+        }
+
+        [Test]
         public void DockCleanup_DetachesChildren_InReverseAttachOrder() {
             var log = new List<string>();
             Dock dock = null;
@@ -91,20 +166,21 @@ namespace Spoke.Tests {
                 return null;
             }));
 
+            dock.Call("x", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("x")); return null; }));
             dock.Call("a", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("a")); return null; }));
-            dock.Call("b", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("b")); return null; }));
-            dock.Call("c", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("c")); return null; }));
+            dock.Call("m", new LambdaEpoch(s => { s.OnCleanup(() => log.Add("m")); return null; }));
 
             tree.Dispose();
 
-            CollectionAssert.AreEqual(new[] { "c", "b", "a" }, log);
+            CollectionAssert.AreEqual(new[] { "m", "a", "x" }, log,
+                "Children detach in reverse attach order (not reverse key order, which would be x, m, a)");
         }
 
         [Test]
         public void CallWhileDetaching_Throws() {
             Exception caught = null;
 
-            using (var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
                 var dock = s.Call(new Dock());
                 dock.Call("k", new LambdaEpoch(s => {
                     s.OnCleanup(() => {
@@ -117,9 +193,9 @@ namespace Spoke.Tests {
                     return null;
                 }));
                 return null;
-            }))) {
-                // Tree disposes here on scope exit
-            }
+            }));
+
+            tree.Dispose();
 
             Assert.IsNotNull(caught, "Dock.Call during detaching should throw");
         }

--- a/Tests~/RuntimeTests/EpochTests.cs
+++ b/Tests~/RuntimeTests/EpochTests.cs
@@ -126,6 +126,27 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void Import_NearestExport_ShadowsFarther() {
+            string imported = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Export("from-root");
+                s.Call(new LambdaEpoch(s => {
+                    s.Export("from-child"); // shadows the root's string export for this subtree
+                    s.Call(new LambdaEpoch(s => {
+                        s.TryImport<string>(out imported);
+                        return null;
+                    }));
+                    return null;
+                }));
+                return null;
+            }));
+
+            Assert.AreEqual("from-child", imported,
+                "Import should resolve the nearest export, shadowing a farther one of the same type");
+        }
+
+        [Test]
         public void Import_NotFound_Throws() {
             Exception captured = null;
 

--- a/Tests~/RuntimeTests/EpochTests.cs
+++ b/Tests~/RuntimeTests/EpochTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class EpochTests : SpokeTestFixture {
+
+        sealed class CounterDisposable : IDisposable {
+            public int Disposed;
+            public void Dispose() => Disposed++;
+        }
+
+        sealed class ThrowingDisposable : IDisposable {
+            public void Dispose() => throw new Exception("dispose boom");
+        }
+
+        [Test]
+        public void Init_RunsSynchronously_DuringCall() {
+            var log = new List<string>();
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                log.Add("parent-init-before-call");
+                s.Call(new LambdaEpoch(s => {
+                    log.Add("child-init");
+                    return null;
+                }));
+                log.Add("parent-init-after-call");
+                return null;
+            }));
+
+            CollectionAssert.AreEqual(
+                new[] { "parent-init-before-call", "child-init", "parent-init-after-call" },
+                log);
+        }
+
+        [Test]
+        public void TickBlock_NotInvoked_DuringConstruction_OnlyOnFlush() {
+            var initRan = false;
+            var tickRan = false;
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                initRan = true;
+                return s => tickRan = true;
+            }));
+            try {
+                Assert.IsTrue(initRan);
+                Assert.IsFalse(tickRan, "TickBlock must not run during construction");
+
+                tree.Flush();
+                Assert.IsTrue(tickRan);
+            } finally {
+                tree.Dispose();
+            }
+        }
+
+        [Test]
+        public void Use_IDisposable_DisposedOnDetach() {
+            var resource = new CounterDisposable();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Use(resource);
+                return null;
+            }));
+            Assert.AreEqual(0, resource.Disposed);
+
+            tree.Dispose();
+            Assert.AreEqual(1, resource.Disposed);
+        }
+
+        [Test]
+        public void Use_SpokeHandle_DisposedOnDetach() {
+            var disposed = 0;
+            var handle = SpokeHandle.Of(0, _ => disposed++);
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Use(handle);
+                return null;
+            }));
+            Assert.AreEqual(0, disposed);
+
+            tree.Dispose();
+            Assert.AreEqual(1, disposed);
+        }
+
+        [Test]
+        public void Export_VisibleTo_LaterSiblings_NotEarlier() {
+            bool? earlySaw = null;
+            bool? lateSaw = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(new LambdaEpoch(s => {
+                    earlySaw = s.TryImport<string>(out _);
+                    return null;
+                }));
+                s.Export("hello");
+                s.Call(new LambdaEpoch(s => {
+                    lateSaw = s.TryImport<string>(out var v) && v == "hello";
+                    return null;
+                }));
+                return null;
+            }));
+
+            Assert.IsFalse(earlySaw.Value, "Earlier sibling should not see later Export");
+            Assert.IsTrue(lateSaw.Value, "Later sibling should see earlier Export");
+        }
+
+        [Test]
+        public void Import_WalksUp_ToAncestor() {
+            string deepImport = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Export("from-root");
+                s.Call(new LambdaEpoch(s => {
+                    s.Call(new LambdaEpoch(s => {
+                        s.TryImport<string>(out deepImport);
+                        return null;
+                    }));
+                    return null;
+                }));
+                return null;
+            }));
+
+            Assert.AreEqual("from-root", deepImport);
+        }
+
+        [Test]
+        public void Import_NotFound_Throws() {
+            Exception captured = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(new LambdaEpoch(s => {
+                    try {
+                        s.Import<DateTime>();
+                    } catch (Exception ex) {
+                        captured = ex;
+                    }
+                    return null;
+                }));
+                return null;
+            }));
+
+            Assert.IsNotNull(captured);
+        }
+
+        [Test]
+        public void TryImport_NotFound_ReturnsFalse() {
+            bool? found = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                found = s.TryImport<DateTime>(out _);
+                return null;
+            }));
+
+            Assert.IsFalse(found.Value);
+        }
+
+        [Test]
+        public void Call_AlreadyAttachedEpoch_FaultsTheTree() {
+            var sharedChild = new LambdaEpoch(s => null);
+            using var tree1 = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(sharedChild);
+                return null;
+            }));
+            Assert.IsNull(tree1.Fault);
+
+            Errors.ExpectErrors();
+            using var tree2 = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(sharedChild); // InvalidOperationException — already attached
+                return null;
+            }));
+
+            Assert.IsNotNull(tree2.Fault, "Second tree should be faulted from re-attach attempt");
+            Assert.IsInstanceOf<InvalidOperationException>(tree2.Fault.InnerException);
+        }
+
+        [Test]
+        public void CapturedEpochBuilder_OutsideMutationWindow_Throws() {
+            EpochBuilder captured = default;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                captured = s;
+                return null;
+            }));
+
+            Assert.Throws<InvalidOperationException>(() => captured.OnCleanup(() => { }));
+        }
+
+        [Test]
+        public void Detach_RunsAttachmentsInReverseOrder_AcrossMixedTypes() {
+            var log = new List<string>();
+            var resourceA = new CounterDisposable();
+            var resourceB = new CounterDisposable();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(new LambdaEpoch(s => {
+                    s.OnCleanup(() => log.Add("childA-cleanup"));
+                    return null;
+                }));
+                s.Use(resourceA);
+                s.OnCleanup(() => log.Add("cleanup-mid"));
+                s.Use(resourceB);
+                s.Call(new LambdaEpoch(s => {
+                    s.OnCleanup(() => log.Add("childB-cleanup"));
+                    return null;
+                }));
+                return null;
+            }));
+
+            tree.Dispose();
+
+            CollectionAssert.AreEqual(
+                new[] { "childB-cleanup", "cleanup-mid", "childA-cleanup" },
+                log);
+            Assert.AreEqual(1, resourceA.Disposed);
+            Assert.AreEqual(1, resourceB.Disposed);
+        }
+
+        [Test]
+        public void CleanupException_IsSwallowed_AndSubsequentCleanupsStillRun() {
+            var lastRan = false;
+            Errors.ExpectErrors();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.OnCleanup(() => throw new Exception("boom"));
+                s.OnCleanup(() => lastRan = true);
+                return null;
+            }));
+            tree.Dispose();
+
+            Assert.IsTrue(lastRan, "Later OnCleanup should run even when a sibling cleanup throws");
+            Assert.Greater(Errors.Entries.Count, 0, "The runtime should have logged at least one entry");
+        }
+
+        [Test]
+        public void DisposeException_IsSwallowed_AndSubsequentCleanupsStillRun() {
+            var lastRan = false;
+            Errors.ExpectErrors();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Use(new ThrowingDisposable());
+                s.OnCleanup(() => lastRan = true);
+                return null;
+            }));
+            tree.Dispose();
+
+            Assert.IsTrue(lastRan);
+            Assert.Greater(Errors.Entries.Count, 0);
+        }
+
+        [Test]
+        public void Services_PassedToSpokeTree_AreImportableByDescendants() {
+            string imported = null;
+
+            using var tree = SpokeTree.SpawnManual(
+                new LambdaEpoch(s => {
+                    s.TryImport<string>(out imported);
+                    return null;
+                }),
+                "service-payload"
+            );
+
+            Assert.AreEqual("service-payload", imported);
+        }
+    }
+}

--- a/Tests~/RuntimeTests/EpochTests.cs
+++ b/Tests~/RuntimeTests/EpochTests.cs
@@ -7,13 +7,10 @@ namespace Spoke.Tests {
     [TestFixture]
     public class EpochTests : SpokeTestFixture {
 
-        sealed class CounterDisposable : IDisposable {
-            public int Disposed;
-            public void Dispose() => Disposed++;
-        }
-
-        sealed class ThrowingDisposable : IDisposable {
-            public void Dispose() => throw new Exception("dispose boom");
+        sealed class Disposable : IDisposable {
+            readonly Action onDispose;
+            public Disposable(Action onDispose) => this.onDispose = onDispose;
+            public void Dispose() => onDispose();
         }
 
         [Test]
@@ -36,7 +33,7 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void TickBlock_NotInvoked_DuringConstruction_OnlyOnFlush() {
+        public void TickBlock_InvokedOnFlush() {
             var initRan = false;
             var tickRan = false;
 
@@ -56,17 +53,69 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void Use_IDisposable_DisposedOnDetach() {
-            var resource = new CounterDisposable();
+        public void RequestTick_ReArmsEpoch_AndCoalescesRepeatRequests() {
+            var ticks = 0;
+            EpochPorts ports = default;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                ports = s.Ports;
+                return s => ticks++;
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, ticks, "ticks once on mount");
+
+            ports.RequestTick();
+            tree.Flush();
+            Assert.AreEqual(2, ticks, "RequestTick re-arms the epoch for another tick");
+
+            ports.RequestTick();
+            ports.RequestTick();
+            ports.RequestTick();
+            tree.Flush();
+            Assert.AreEqual(3, ticks, "repeat RequestTicks before a flush coalesce into a single tick");
+        }
+
+        [Test]
+        public void Tick_RollsBackPriorTickAttachments_ButKeepsInitAttachments() {
+            var log = new List<string>();
+            EpochPorts ports = default;
+            var n = 0;
 
             var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
-                s.Use(resource);
+                s.OnCleanup(() => log.Add("init-cleanup"));   // attached in Init: persists across ticks
+                ports = s.Ports;
+                return s => {
+                    var i = n++;
+                    log.Add($"tick:{i}");
+                    s.OnCleanup(() => log.Add($"tick-cleanup:{i}"));  // attached in Tick: rolled back next tick
+                };
+            }));
+
+            tree.Flush();                       // tick 0
+            ports.RequestTick(); tree.Flush();  // tick 1
+            ports.RequestTick(); tree.Flush();  // tick 2
+            tree.Dispose();
+
+            CollectionAssert.AreEqual(new[] {
+                "tick:0", "tick-cleanup:0",   // tick 1 rolls back tick 0's attachment before rebuilding
+                "tick:1", "tick-cleanup:1",   // tick 2 rolls back tick 1's
+                "tick:2", "tick-cleanup:2",   // dispose rolls back tick 2's
+                "init-cleanup",               // the Init attachment runs only on detach
+            }, log);
+        }
+
+        [Test]
+        public void Use_IDisposable_DisposedOnDetach() {
+            var disposed = 0;
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Use(new Disposable(() => disposed++));
                 return null;
             }));
-            Assert.AreEqual(0, resource.Disposed);
+            Assert.AreEqual(0, disposed);
 
             tree.Dispose();
-            Assert.AreEqual(1, resource.Disposed);
+            Assert.AreEqual(1, disposed);
         }
 
         [Test]
@@ -211,17 +260,15 @@ namespace Spoke.Tests {
         [Test]
         public void Detach_RunsAttachmentsInReverseOrder_AcrossMixedTypes() {
             var log = new List<string>();
-            var resourceA = new CounterDisposable();
-            var resourceB = new CounterDisposable();
 
             var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
                 s.Call(new LambdaEpoch(s => {
                     s.OnCleanup(() => log.Add("childA-cleanup"));
                     return null;
                 }));
-                s.Use(resourceA);
+                s.Use(new Disposable(() => log.Add("resourceA")));
                 s.OnCleanup(() => log.Add("cleanup-mid"));
-                s.Use(resourceB);
+                s.Use(new Disposable(() => log.Add("resourceB")));
                 s.Call(new LambdaEpoch(s => {
                     s.OnCleanup(() => log.Add("childB-cleanup"));
                     return null;
@@ -232,10 +279,8 @@ namespace Spoke.Tests {
             tree.Dispose();
 
             CollectionAssert.AreEqual(
-                new[] { "childB-cleanup", "cleanup-mid", "childA-cleanup" },
+                new[] { "childB-cleanup", "resourceB", "cleanup-mid", "resourceA", "childA-cleanup" },
                 log);
-            Assert.AreEqual(1, resourceA.Disposed);
-            Assert.AreEqual(1, resourceB.Disposed);
         }
 
         [Test]
@@ -244,13 +289,13 @@ namespace Spoke.Tests {
             Errors.ExpectErrors();
 
             var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.OnCleanup(() => lastRan = true);          // runs after the throwing one (reverse order)
                 s.OnCleanup(() => throw new Exception("boom"));
-                s.OnCleanup(() => lastRan = true);
                 return null;
             }));
             tree.Dispose();
 
-            Assert.IsTrue(lastRan, "Later OnCleanup should run even when a sibling cleanup throws");
+            Assert.IsTrue(lastRan, "A cleanup that runs after a throwing one should still run");
             Assert.Greater(Errors.Entries.Count, 0, "The runtime should have logged at least one entry");
         }
 
@@ -260,13 +305,13 @@ namespace Spoke.Tests {
             Errors.ExpectErrors();
 
             var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
-                s.Use(new ThrowingDisposable());
-                s.OnCleanup(() => lastRan = true);
+                s.OnCleanup(() => lastRan = true);          // runs after the throwing dispose (reverse order)
+                s.Use(new Disposable(() => throw new Exception("dispose boom")));
                 return null;
             }));
             tree.Dispose();
 
-            Assert.IsTrue(lastRan);
+            Assert.IsTrue(lastRan, "A cleanup that runs after a throwing dispose should still run");
             Assert.Greater(Errors.Entries.Count, 0);
         }
 

--- a/Tests~/RuntimeTests/FaultTests.cs
+++ b/Tests~/RuntimeTests/FaultTests.cs
@@ -1,0 +1,100 @@
+using System;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class FaultTests : SpokeTestFixture {
+
+        [Test]
+        public void InitException_WrapsInSpokeException_AndMarksFaulted() {
+            Errors.ExpectErrors();
+            var faulty = new LambdaEpoch(s => throw new Exception("init-boom"));
+
+            using var tree = SpokeTree.SpawnManual(faulty);
+
+            Assert.IsNotNull(faulty.Fault);
+            Assert.IsInstanceOf<Exception>(faulty.Fault.InnerException);
+        }
+
+        [Test]
+        public void TickException_WrapsInSpokeException_AndMarksFaulted() {
+            Errors.ExpectErrors();
+            var faulty = new LambdaEpoch(s => s => throw new Exception("tick-boom"));
+
+            using var tree = SpokeTree.SpawnManual(faulty);
+            tree.Flush();
+
+            Assert.IsNotNull(faulty.Fault);
+        }
+
+        [Test]
+        public void FaultedEpoch_StopsRequestingTicks() {
+            Errors.ExpectErrors();
+            var ticks = 0;
+            EpochPorts ports = default;
+            var faulty = new LambdaEpoch(s => {
+                ports = s.Ports;
+                return s => {
+                    ticks++;
+                    if (ticks == 1) throw new Exception("first-tick-only");
+                };
+            });
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(faulty);
+                return null;
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, ticks);
+            Assert.IsNotNull(faulty.Fault);
+
+            ports.RequestTick();
+            tree.Flush();
+            Assert.AreEqual(1, ticks, "Faulted epoch should not re-tick");
+        }
+
+        [Test]
+        public void Fault_PropagatesUpToSpokeTree() {
+            Errors.ExpectErrors();
+            var faulty = new LambdaEpoch(s => throw new Exception("boom"));
+
+            using var tree = SpokeTree.SpawnManual(faulty);
+
+            Assert.IsNotNull(tree.Fault, "Fault from descendant should propagate to SpokeTree");
+        }
+
+        [Test]
+        public void SpokeException_CarriesStackSnapshot() {
+            Errors.ExpectErrors();
+            var faulty = new LambdaEpoch(s => throw new Exception("boom"));
+
+            using var tree = SpokeTree.SpawnManual(faulty);
+
+            Assert.IsNotNull(faulty.Fault);
+            Assert.Greater(faulty.Fault.StackSnapshot.Count, 0,
+                "Stack snapshot should contain frames captured at fault time");
+        }
+
+        [Test]
+        public void SkipMarkFaulted_PreventsMarkingThatLayer_ButLetsPropagationContinue() {
+            Errors.ExpectErrors();
+            var childFaulty = new LambdaEpoch(s => throw new Exception("child-boom"));
+            var middle = new LambdaEpoch(s => {
+                try {
+                    s.Call(childFaulty);
+                } catch (SpokeException se) {
+                    se.SkipMarkFaulted = true;
+                    throw;
+                }
+                return null;
+            });
+
+            using var tree = SpokeTree.SpawnManual(middle);
+
+            Assert.IsNotNull(childFaulty.Fault, "Inner epoch should be faulted");
+            Assert.IsNull(middle.Fault, "Middle with SkipMarkFaulted=true should NOT be marked faulted");
+            Assert.IsNotNull(tree.Fault, "Tree should still be marked (SkipMarkFaulted resets after one layer)");
+        }
+    }
+}

--- a/Tests~/RuntimeTests/HeapTests.cs
+++ b/Tests~/RuntimeTests/HeapTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class HeapTests : SpokeTestFixture {
+
+        [Test]
+        public void Insert_RemoveMin_YieldsAscendingOrder() {
+            var heap = new Heap<int>((a, b) => a.CompareTo(b));
+            foreach (var v in new[] { 5, 1, 3, 2, 4 }) heap.Insert(v);
+
+            var actual = new List<int>();
+            while (heap.Count > 0) actual.Add(heap.RemoveMin());
+
+            CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, actual);
+        }
+
+        [Test]
+        public void PeekMin_DoesNotRemove() {
+            var heap = new Heap<int>((a, b) => a.CompareTo(b));
+            heap.Insert(7);
+            heap.Insert(2);
+
+            Assert.AreEqual(2, heap.PeekMin());
+            Assert.AreEqual(2, heap.Count);
+        }
+
+        [Test]
+        public void PeekMin_OnEmpty_Throws() {
+            var heap = new Heap<int>((a, b) => a.CompareTo(b));
+            Assert.Throws<InvalidOperationException>(() => heap.PeekMin());
+        }
+
+        [Test]
+        public void RemoveMin_OnEmpty_Throws() {
+            var heap = new Heap<int>((a, b) => a.CompareTo(b));
+            Assert.Throws<InvalidOperationException>(() => heap.RemoveMin());
+        }
+
+        [Test]
+        public void Stress_RandomInserts_RemoveMinIsSorted() {
+            var rng = new Random(42);
+            var heap = new Heap<int>((a, b) => a.CompareTo(b));
+            var inserted = new List<int>();
+            for (int i = 0; i < 100; i++) {
+                var v = rng.Next();
+                heap.Insert(v);
+                inserted.Add(v);
+            }
+            inserted.Sort();
+
+            var drained = new List<int>();
+            while (heap.Count > 0) drained.Add(heap.RemoveMin());
+            CollectionAssert.AreEqual(inserted, drained);
+        }
+    }
+}

--- a/Tests~/RuntimeTests/ReadOnlyListTests.cs
+++ b/Tests~/RuntimeTests/ReadOnlyListTests.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class ReadOnlyListTests : SpokeTestFixture {
+
+        [Test]
+        public void Count_And_Indexer() {
+            var inner = new List<int> { 10, 20, 30 };
+            var rol = new ReadOnlyList<int>(inner);
+            Assert.AreEqual(3, rol.Count);
+            Assert.AreEqual(10, rol[0]);
+            Assert.AreEqual(30, rol[2]);
+        }
+
+        [Test]
+        public void Enumeration_YieldsAll() {
+            var rol = new ReadOnlyList<int>(new List<int> { 1, 2, 3 });
+            var collected = new List<int>();
+            foreach (var v in rol) collected.Add(v);
+            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, collected);
+        }
+
+        [Test]
+        public void NullList_CountIsZero() {
+            var rol = new ReadOnlyList<int>(null);
+            Assert.AreEqual(0, rol.Count);
+        }
+    }
+}

--- a/Tests~/RuntimeTests/SpokeHandleTests.cs
+++ b/Tests~/RuntimeTests/SpokeHandleTests.cs
@@ -1,0 +1,42 @@
+using System;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class SpokeHandleTests : SpokeTestFixture {
+
+        [Test]
+        public void Dispose_InvokesOnDispose() {
+            long captured = -1;
+            var handle = SpokeHandle.Of(42, id => captured = id);
+            handle.Dispose();
+            Assert.AreEqual(42, captured);
+        }
+
+        [Test]
+        public void Dispose_OnDefault_IsSafe() {
+            var handle = default(SpokeHandle);
+            Assert.DoesNotThrow(() => handle.Dispose());
+        }
+
+        [Test]
+        public void Equals_AndHashCode_AreConsistent() {
+            Action<long> dispose = _ => { };
+            var a = SpokeHandle.Of(7, dispose);
+            var b = SpokeHandle.Of(7, dispose);
+            Assert.IsTrue(a == b);
+            Assert.IsFalse(a != b);
+            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Test]
+        public void Equals_DifferentId_AreNotEqual() {
+            Action<long> dispose = _ => { };
+            var a = SpokeHandle.Of(7, dispose);
+            var c = SpokeHandle.Of(8, dispose);
+            Assert.IsFalse(a == c);
+            Assert.IsTrue(a != c);
+        }
+    }
+}

--- a/Tests~/RuntimeTests/SpokePoolTests.cs
+++ b/Tests~/RuntimeTests/SpokePoolTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class SpokePoolTests : SpokeTestFixture {
+
+        [Test]
+        public void Get_WhenEmpty_ReturnsNewInstance() {
+            var pool = SpokePool<List<int>>.Create();
+            var got = pool.Get();
+            Assert.IsNotNull(got);
+        }
+
+        [Test]
+        public void ReturnThenGet_ReturnsSameInstance() {
+            var pool = SpokePool<List<int>>.Create();
+            var first = pool.Get();
+            pool.Return(first);
+            var second = pool.Get();
+            Assert.AreSame(first, second);
+        }
+
+        [Test]
+        public void Return_InvokesResetAction() {
+            var resets = 0;
+            var pool = SpokePool<List<int>>.Create(l => { l.Clear(); resets++; });
+            var bucket = pool.Get();
+            bucket.Add(1);
+            bucket.Add(2);
+            pool.Return(bucket);
+            Assert.AreEqual(1, resets);
+            Assert.AreEqual(0, bucket.Count, "reset should have cleared the list");
+        }
+    }
+}

--- a/Tests~/RuntimeTests/SpokeRuntimeTests.cs
+++ b/Tests~/RuntimeTests/SpokeRuntimeTests.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    [NonParallelizable]
+    public class SpokeRuntimeTests : SpokeTestFixture {
+
+        [Test]
+        public void LambdaEpoch_InitBlock_RunsDuringTreeConstruction() {
+            var initRan = 0;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                initRan++;
+                return null;
+            }));
+
+            Assert.AreEqual(1, initRan, "Init block should run synchronously during tree construction");
+        }
+
+        [Test]
+        public void TickBlock_RunsOnFlush() {
+            var ticks = 0;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                return s => ticks++;
+            }));
+
+            tree.Flush();
+            Assert.AreEqual(1, ticks);
+        }
+
+        [Test]
+        public void OnCleanup_RunsOnDispose_InReverseOrder() {
+            var order = new List<string>();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.OnCleanup(() => order.Add("first"));
+                s.OnCleanup(() => order.Add("second"));
+                return null;
+            }));
+
+            tree.Dispose();
+
+            CollectionAssert.AreEqual(new[] { "second", "first" }, order);
+        }
+
+        [Test]
+        public void Batch_DefersFlushUntilDelegateCompletes() {
+            var ticks = 0;
+            EpochPorts ports = default;
+
+            using var tree = SpokeTree.Spawn(new LambdaEpoch(s => {
+                ports = s.Ports;
+                return s => ticks++;
+            }));
+            Assert.AreEqual(1, ticks);
+
+            SpokeRuntime.Batch(() => {
+                ports.RequestTick();
+                Assert.AreEqual(1, ticks, "Re-tick must not have run yet — Batch should hold the flush");
+            });
+
+            Assert.AreEqual(2, ticks);
+        }
+
+        [Test]
+        public void Batch_NestedHolds_Stack() {
+            var ticks = 0;
+            EpochPorts ports = default;
+
+            using var tree = SpokeTree.Spawn(new LambdaEpoch(s => {
+                ports = s.Ports;
+                return s => ticks++;
+            }));
+            Assert.AreEqual(1, ticks);
+
+            SpokeRuntime.Batch(() => {
+                SpokeRuntime.Batch(() => {
+                    ports.RequestTick();
+                });
+                Assert.AreEqual(1, ticks, "Outer Batch should still hold even after inner Batch exits");
+            });
+
+            Assert.AreEqual(2, ticks);
+        }
+
+        [Test]
+        public void AutoTrees_OrderedByCreation_WhenSameFlushLayer() {
+            var log = new List<string>();
+            SpokeTree<LambdaEpoch> t1 = null;
+            SpokeTree<LambdaEpoch> t2 = null;
+
+            SpokeRuntime.Batch(() => {
+                t1 = SpokeTree.Spawn("T1", new LambdaEpoch(s => s => log.Add("T1")));
+                t2 = SpokeTree.Spawn("T2", new LambdaEpoch(s => s => log.Add("T2")));
+            });
+
+            try {
+                CollectionAssert.AreEqual(new[] { "T1", "T2" }, log);
+            } finally {
+                t1?.Dispose();
+                t2?.Dispose();
+            }
+        }
+
+        [Test]
+        public void SpawnEager_OutranksSpawn_WhenSameBatch() {
+            var log = new List<string>();
+            SpokeTree<LambdaEpoch> dflt = null;
+            SpokeTree<LambdaEpoch> eager = null;
+
+            SpokeRuntime.Batch(() => {
+                dflt = SpokeTree.Spawn("Default", new LambdaEpoch(s => s => log.Add("Default")));
+                eager = SpokeTree.SpawnEager("Eager", new LambdaEpoch(s => s => log.Add("Eager")));
+            });
+
+            try {
+                CollectionAssert.AreEqual(new[] { "Eager", "Default" }, log);
+            } finally {
+                dflt?.Dispose();
+                eager?.Dispose();
+            }
+        }
+
+        [Test]
+        public void NestedTreeSpawn_DuringFlush_FlushesNestedInScope() {
+            var log = new List<string>();
+            SpokeTree<LambdaEpoch> inner = null;
+
+            using var outer = SpokeTree.Spawn("Outer", new LambdaEpoch(s => s => {
+                log.Add("Before");
+                inner = SpokeTree.Spawn("Inner", new LambdaEpoch(s => s => log.Add("Inner")));
+                log.Add("After");
+            }));
+            try {
+                CollectionAssert.AreEqual(new[] { "Before", "Inner", "After" }, log);
+            } finally {
+                inner?.Dispose();
+            }
+        }
+
+    }
+}

--- a/Tests~/RuntimeTests/SpokeRuntimeTests.cs
+++ b/Tests~/RuntimeTests/SpokeRuntimeTests.cs
@@ -8,45 +8,6 @@ namespace Spoke.Tests {
     public class SpokeRuntimeTests : SpokeTestFixture {
 
         [Test]
-        public void LambdaEpoch_InitBlock_RunsDuringTreeConstruction() {
-            var initRan = 0;
-
-            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
-                initRan++;
-                return null;
-            }));
-
-            Assert.AreEqual(1, initRan, "Init block should run synchronously during tree construction");
-        }
-
-        [Test]
-        public void TickBlock_RunsOnFlush() {
-            var ticks = 0;
-
-            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
-                return s => ticks++;
-            }));
-
-            tree.Flush();
-            Assert.AreEqual(1, ticks);
-        }
-
-        [Test]
-        public void OnCleanup_RunsOnDispose_InReverseOrder() {
-            var order = new List<string>();
-
-            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
-                s.OnCleanup(() => order.Add("first"));
-                s.OnCleanup(() => order.Add("second"));
-                return null;
-            }));
-
-            tree.Dispose();
-
-            CollectionAssert.AreEqual(new[] { "second", "first" }, order);
-        }
-
-        [Test]
         public void Batch_DefersFlushUntilDelegateCompletes() {
             var ticks = 0;
             EpochPorts ports = default;

--- a/Tests~/RuntimeTests/SpokeRuntimeTests.cs
+++ b/Tests~/RuntimeTests/SpokeRuntimeTests.cs
@@ -141,5 +141,36 @@ namespace Spoke.Tests {
             }
         }
 
+        [Test]
+        public void SpawnEager_EnablesWriteThenRead_ViaNestedFlush() {
+            // SpawnEager gives a tree a higher-priority flush layer. When a lower-priority (default) tree
+            // mutates a signal the eager tree depends on, the eager tree flushes NESTED — synchronously,
+            // before the default tree's flush continues. That lets the default tree write a signal and
+            // then read a value the eager tree derives from it, fresh, in the same flush ("write-then-read").
+            // Were both trees the same priority, the derived read would be stale (0 here, not 10).
+            var src = State.Create(0);
+            var derived = State.Create(0);
+            var go = State.Create(false);
+            var observed = -1;
+
+            // Eager tree keeps `derived` == src * 2.
+            var eager = SpokeTree.SpawnEager(new Effect("derive", s => derived.Set(s.D(src) * 2)));
+            // Default tree: on `go`, writes src and immediately reads the eager-derived value.
+            var dflt = SpokeTree.Spawn(new Effect("writer", s => {
+                if (s.D(go)) {
+                    src.Set(5);
+                    observed = derived.Now;
+                }
+            }));
+            try {
+                go.Set(true);
+                Assert.AreEqual(10, observed,
+                    "Eager tree must flush nested when src changes, so the default tree reads the fresh derived value");
+            } finally {
+                dflt.Dispose();
+                eager.Dispose();
+            }
+        }
+
     }
 }

--- a/Tests~/RuntimeTests/SpokeTreeTests.cs
+++ b/Tests~/RuntimeTests/SpokeTreeTests.cs
@@ -139,5 +139,28 @@ namespace Spoke.Tests {
 
             Assert.IsNotNull(tree.Fault, "Tree should be faulted by oscillation guard");
         }
+
+        [Test]
+        public void Dispose_DuringFlush_IsDeferredUntilFlushCompletes() {
+            // Disposing a tree from inside its own flush must NOT tear it down mid-tick — that would
+            // pull the rug out from under the executing epoch. SpokeTree.Dispose defers the detach until
+            // the live flush frame pops, so the current unit of work finishes first, then teardown runs.
+            var log = new List<string>();
+            SpokeTree tree = null;
+
+            tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.OnCleanup(() => log.Add("cleanup"));
+                return s => {
+                    log.Add("before-dispose");
+                    tree.Dispose();   // mid-flush: detach must be deferred, not immediate
+                    log.Add("after-dispose"); // proves this tick wasn't torn down underneath us
+                };
+            }));
+
+            tree.Flush();
+
+            CollectionAssert.AreEqual(new[] { "before-dispose", "after-dispose", "cleanup" }, log,
+                "Dispose during a flush must defer teardown until the current flush completes");
+        }
     }
 }

--- a/Tests~/RuntimeTests/SpokeTreeTests.cs
+++ b/Tests~/RuntimeTests/SpokeTreeTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    [NonParallelizable]
+    public class SpokeTreeTests : SpokeTestFixture {
+
+        [Test]
+        public void Flush_ThrowsWhenAutoMode() {
+            using var tree = SpokeTree.Spawn(new LambdaEpoch(s => null));
+            Assert.Throws<Exception>(() => tree.Flush());
+        }
+
+        [Test]
+        public void Tick_ThrowsWhenAutoMode() {
+            using var tree = SpokeTree.Spawn(new LambdaEpoch(s => null));
+            Assert.Throws<Exception>(() => tree.Tick());
+        }
+
+        [Test]
+        public void Flush_ThrowsOnReentrancy() {
+            SpokeTree<LambdaEpoch> capturedTree = null;
+            bool? reentryThrew = null;
+
+            capturedTree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                return s => {
+                    try {
+                        capturedTree.Flush();
+                        reentryThrew = false;
+                    } catch (Exception) {
+                        reentryThrew = true;
+                    }
+                };
+            }));
+            try {
+                capturedTree.Flush();
+                Assert.IsTrue(reentryThrew.HasValue && reentryThrew.Value,
+                    "Re-entrant Flush should throw");
+            } finally {
+                capturedTree.Dispose();
+            }
+        }
+
+        [Test]
+        public void Tick_AdvancesExactlyOnePending_FlushDrainsRest() {
+            var ticked = new List<int>();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(new LambdaEpoch(s => s => ticked.Add(1)));
+                s.Call(new LambdaEpoch(s => s => ticked.Add(2)));
+                s.Call(new LambdaEpoch(s => s => ticked.Add(3)));
+                return null;
+            }));
+            try {
+                tree.Tick();
+                CollectionAssert.AreEqual(new[] { 1 }, ticked);
+
+                tree.Flush();
+                CollectionAssert.AreEqual(new[] { 1, 2, 3 }, ticked);
+            } finally {
+                tree.Dispose();
+            }
+        }
+
+        [Test]
+        public void Flush_DrainsAllPending() {
+            var ticked = new List<int>();
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(new LambdaEpoch(s => s => ticked.Add(1)));
+                s.Call(new LambdaEpoch(s => s => ticked.Add(2)));
+                s.Call(new LambdaEpoch(s => s => ticked.Add(3)));
+                return null;
+            }));
+
+            tree.Flush();
+            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, ticked);
+        }
+
+        [Test]
+        public void Dispose_DetachesEntireSubtree() {
+            var cleanups = new List<string>();
+
+            var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.OnCleanup(() => cleanups.Add("root"));
+                s.Call(new LambdaEpoch(s => {
+                    s.OnCleanup(() => cleanups.Add("child"));
+                    s.Call(new LambdaEpoch(s => {
+                        s.OnCleanup(() => cleanups.Add("grand"));
+                        return null;
+                    }));
+                    return null;
+                }));
+                return null;
+            }));
+
+            tree.Dispose();
+
+            CollectionAssert.AreEqual(new[] { "grand", "child", "root" }, cleanups);
+        }
+
+        [Test]
+        public void AutoTree_FlushesSynchronously_WhenUserRequestsTick() {
+            var ticks = 0;
+            EpochPorts ports = default;
+
+            using var tree = SpokeTree.Spawn(new LambdaEpoch(s => {
+                ports = s.Ports;
+                return s => ticks++;
+            }));
+            Assert.AreEqual(1, ticks);
+
+            ports.RequestTick();
+
+            Assert.AreEqual(2, ticks, "Requesting a tick from user code must synchronously flush the Auto tree");
+        }
+
+        [Test]
+        public void OscillationGuard_FaultsTheTree_WhenEpochsPingPong() {
+            Errors.ExpectErrors();
+            EpochPorts p1 = default, p2 = default;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                s.Call(new LambdaEpoch(s => {
+                    p1 = s.Ports;
+                    return s => p2.RequestTick(); // e1 re-arms e2 on every tick
+                }));
+                s.Call(new LambdaEpoch(s => {
+                    p2 = s.Ports;
+                    return s => p1.RequestTick(); // e2 re-arms e1 on every tick
+                }));
+                return null;
+            }));
+
+            tree.Flush();
+
+            Assert.IsNotNull(tree.Fault, "Tree should be faulted by oscillation guard");
+        }
+    }
+}

--- a/Tests~/RuntimeTests/TickerTests.cs
+++ b/Tests~/RuntimeTests/TickerTests.cs
@@ -16,7 +16,7 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void OnTick_DoingNothing_FaultsTree() {
+        public void OnTick_DoingNothing_ThrowsFault() {
             Errors.ExpectErrors();
             using var tree = SpokeTree.SpawnManual(new LambdaTicker(s => {
                 s.OnTick(s => {

--- a/Tests~/RuntimeTests/TickerTests.cs
+++ b/Tests~/RuntimeTests/TickerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Spoke.Tests {
@@ -47,6 +48,62 @@ namespace Spoke.Tests {
             tree.Flush();
 
             CollectionAssert.AreEqual(new[] { 0, 1, 2 }, ticked);
+        }
+
+        [Test]
+        public void Ticker_AlwaysTicksLowestPendingCoordFirst_UnderChaoticScheduling() {
+            // The strong form of "ticks in tree-coord order": regardless of WHEN or in what ORDER epochs
+            // become pending — including epochs re-arming arbitrary others mid-flush — the ticker must
+            // always service the lowest tree-coord pending epoch next. We fuzz the scheduling with a
+            // seeded RNG and assert that invariant at EVERY TickNext: the epoch ticked is the minimum
+            // of the currently-pending set. (The simpler test above can't catch reordering — its attach,
+            // request, and coord orders all coincide.)
+            const int N = 8;
+            var rng = new Random(98765);
+            var ports = new EpochPorts[N];
+            var pending = new HashSet<int>(); // test-side mirror of the engine's pending set
+            var rearmBudget = 300;            // bound the mid-flush chaos so each drain terminates
+
+            void Request(int i) { pending.Add(i); ports[i].RequestTick(); }
+
+            using var tree = SpokeTree.SpawnManual(new LambdaTicker(s => {
+                var tp = s.Ports;
+                s.OnTick(s => { while (tp.HasPending) s.TickNext(); });
+                return new LambdaEpoch(s => {
+                    for (int i = 0; i < N; i++) {
+                        int idx = i; // siblings: tree-coord order == idx order
+                        s.Call(new LambdaEpoch(s => {
+                            ports[idx] = s.Ports;
+                            return s => {
+                                Assert.AreEqual(pending.Min(), idx,
+                                    "Ticker must tick the lowest tree-coord pending epoch next");
+                                pending.Remove(idx);
+                                // chaotically re-arm a bounded number of arbitrary epochs
+                                for (int k = rng.Next(0, 3); k > 0 && rearmBudget > 0; k--) {
+                                    rearmBudget--;
+                                    Request(rng.Next(0, N));
+                                }
+                            };
+                        }));
+                    }
+                    return null;
+                });
+            }));
+
+            // On mount every child auto-arms, so all N are pending before the first flush.
+            for (int i = 0; i < N; i++) pending.Add(i);
+            tree.Flush();
+
+            // Then many rounds of scrambled external requests; each drain must still be coord-ordered.
+            for (int round = 0; round < 50; round++) {
+                var order = Enumerable.Range(0, N).OrderBy(_ => rng.Next()).ToArray();
+                var count = rng.Next(1, N + 1);
+                for (int j = 0; j < count; j++) Request(order[j]);
+                tree.Flush();
+            }
+
+            Assert.IsNull(tree.Fault, "bounded chaotic scheduling must not fault the tree");
+            Assert.IsEmpty(pending, "all scheduled work drained");
         }
 
         [Test]

--- a/Tests~/RuntimeTests/TickerTests.cs
+++ b/Tests~/RuntimeTests/TickerTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class TickerTests : SpokeTestFixture {
+
+        sealed class LambdaTicker : Ticker {
+            readonly Func<TickerBuilder, Epoch> block;
+            public LambdaTicker(string name, Func<TickerBuilder, Epoch> block) { Name = name; this.block = block; }
+            public LambdaTicker(Func<TickerBuilder, Epoch> block) : this("LambdaTicker", block) { }
+            protected override Epoch Bootstrap(TickerBuilder s) => block(s);
+        }
+
+        [Test]
+        public void OnTick_DoingNothing_FaultsTree() {
+            Errors.ExpectErrors();
+            using var tree = SpokeTree.SpawnManual(new LambdaTicker(s => {
+                s.OnTick(s => {
+                    // Intentionally do nothing — neither TickNext nor Pause
+                });
+                return new LambdaEpoch(s => null);
+            }));
+
+            tree.Flush();
+            Assert.IsNotNull(tree.Fault, "Ticker should throw when OnTick neither advances nor pauses");
+        }
+
+        [Test]
+        public void Ticker_TicksPending_InTreeCoordOrder() {
+            var ticked = new List<int>();
+
+            using var tree = SpokeTree.SpawnManual(new LambdaTicker(s => {
+                var ports = s.Ports;
+                s.OnTick(s => {
+                    while (ports.HasPending) s.TickNext();
+                });
+                return new LambdaEpoch(s => {
+                    s.Call(new LambdaEpoch(s => s => ticked.Add(0)));
+                    s.Call(new LambdaEpoch(s => s => ticked.Add(1)));
+                    s.Call(new LambdaEpoch(s => s => ticked.Add(2)));
+                    return null;
+                });
+            }));
+            tree.Flush();
+
+            CollectionAssert.AreEqual(new[] { 0, 1, 2 }, ticked);
+        }
+
+        [Test]
+        public void Pause_StopsFurtherTicks_ResumeRestarts() {
+            var ticks = 0;
+            var pauseAfterDraining = false;
+            EpochPorts child = default;
+            TickerPorts ports = default;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaTicker(s => {
+                ports = s.Ports;
+                s.OnTick(s => {
+                    ticks++;
+                    while (ports.HasPending) s.TickNext();
+                    if (pauseAfterDraining) ports.Pause();
+                });
+                return new LambdaEpoch(s => {
+                    child = s.Ports;
+                    return s => { };
+                });
+            }));
+            tree.Flush();
+            Assert.AreEqual(1, ticks);
+
+            pauseAfterDraining = true;
+            child.RequestTick();
+            tree.Flush();
+            Assert.AreEqual(2, ticks, "Ticker should fire once more to process the new pending and then pause");
+
+            child.RequestTick();
+            tree.Flush();
+            Assert.AreEqual(2, ticks, "Paused ticker should not fire");
+
+            ports.Resume();
+            tree.Flush();
+            Assert.Greater(ticks, 2, "Resume should let the ticker fire again");
+        }
+
+        [Test]
+        public void FaultBoundaryTicker_ContainsException_TreeStaysHealthy() {
+            Errors.ExpectErrors();
+            var innerRan = 0;
+
+            var boundary = new LambdaTicker(s => {
+                var ports = s.Ports;
+                s.OnTick(s => {
+                    try {
+                        while (ports.HasPending) s.TickNext();
+                    } catch (SpokeException) {
+                        ports.Pause();
+                    }
+                });
+                return new LambdaEpoch(s => s => {
+                    innerRan++;
+                    throw new Exception("inner-explode");
+                });
+            });
+
+            using var tree = SpokeTree.SpawnManual(boundary);
+            tree.Flush();
+
+            Assert.AreEqual(1, innerRan, "Inner epoch must have run (and thrown) before boundary caught");
+            Assert.IsNull(tree.Fault, "Tree should not fault — boundary contained the exception");
+            Assert.IsNull(boundary.Fault, "Boundary's own tickBlock didn't throw, only its inner epoch did");
+        }
+    }
+}

--- a/Tests~/RuntimeTests/TreeCoordsTests.cs
+++ b/Tests~/RuntimeTests/TreeCoordsTests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    [TestFixture]
+    public class TreeCoordsTests : SpokeTestFixture {
+
+        [Test]
+        public void Extend_BuildsDeeperCoord() {
+            var root = default(TreeCoords);
+            var child = root.Extend(0);
+            var grandchild = child.Extend(3);
+
+            Assert.AreEqual(0, child.Tail);
+            Assert.AreEqual(3, grandchild.Tail);
+        }
+
+        [Test]
+        public void Compare_ParentBeforeDeeperChild() {
+            var parent = default(TreeCoords).Extend(0);
+            var child = parent.Extend(0);
+            Assert.Less(parent.CompareTo(child), 0);
+            Assert.Greater(child.CompareTo(parent), 0);
+        }
+
+        [Test]
+        public void Compare_LeftSiblingBeforeRight() {
+            var left = default(TreeCoords).Extend(0);
+            var right = default(TreeCoords).Extend(1);
+            Assert.Less(left.CompareTo(right), 0);
+        }
+
+        [Test]
+        public void Compare_NestedOrderingMatchesImperativeWalk() {
+            // Mimics the tree in 00_SpokeRuntime.md §Ordering Epochs by Tree Coords:
+            //   []          (tree root)
+            //   [0]         (Main)
+            //   [0,0]       (epoch)
+            //   [0,0,0]     (epoch *)
+            //   [0,0,1]
+            //   [0,1]       (epoch *)
+            //   [0,1,0]     (epoch *)
+            //   [0,1,1]
+            var coords = new[] {
+                default(TreeCoords),
+                default(TreeCoords).Extend(0),
+                default(TreeCoords).Extend(0).Extend(0),
+                default(TreeCoords).Extend(0).Extend(0).Extend(0),
+                default(TreeCoords).Extend(0).Extend(0).Extend(1),
+                default(TreeCoords).Extend(0).Extend(1),
+                default(TreeCoords).Extend(0).Extend(1).Extend(0),
+                default(TreeCoords).Extend(0).Extend(1).Extend(1),
+            };
+            for (int i = 0; i < coords.Length - 1; i++) {
+                Assert.Less(coords[i].CompareTo(coords[i + 1]), 0, $"coord[{i}] should be before coord[{i + 1}]");
+            }
+        }
+
+        [Test]
+        public void Compare_SlowPath_ProducesSameOrderingAsPacked() {
+            // Force slow path with val > 255
+            var a = default(TreeCoords).Extend(300);
+            var b = default(TreeCoords).Extend(400);
+            Assert.Less(a.CompareTo(b), 0);
+            Assert.Greater(b.CompareTo(a), 0);
+        }
+    }
+}

--- a/Tests~/RuntimeTests/TreeCoordsTests.cs
+++ b/Tests~/RuntimeTests/TreeCoordsTests.cs
@@ -32,7 +32,7 @@ namespace Spoke.Tests {
 
         [Test]
         public void Compare_NestedOrderingMatchesImperativeWalk() {
-            // Mimics the tree in 00_SpokeRuntime.md §Ordering Epochs by Tree Coords:
+            // A representative epoch tree — coords must sort in depth-first (imperative walk) order:
             //   []          (tree root)
             //   [0]         (Main)
             //   [0,0]       (epoch)

--- a/Tests~/Spoke.Tests.csproj
+++ b/Tests~/Spoke.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Spoke.Tests</RootNamespace>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Spoke.Runtime\**\*.cs" LinkBase="Spoke.Runtime" />
+    <Compile Include="..\Spoke.Reactive\**\*.cs" LinkBase="Spoke.Reactive" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/Tests~/SpokeTestFixture.cs
+++ b/Tests~/SpokeTestFixture.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Spoke.Tests {
+
+    /// <summary>
+    /// Base for every Spoke test fixture. Installs a capture over the global SpokeError.Log sink
+    /// for the duration of each test, and fails the test in teardown if anything was logged that
+    /// the test didn't explicitly opt into via Errors.ExpectErrors().
+    /// This makes error-capture uniform (always on) rather than something each test remembers to add,
+    /// and turns an unexpected runtime error-log into a test failure instead of silent console noise.
+    /// </summary>
+    public abstract class SpokeTestFixture {
+        protected CapturedErrors Errors { get; private set; }
+
+        [SetUp]
+        public void __InstallErrorCapture() => Errors = new CapturedErrors();
+
+        [TearDown]
+        public void __AssertNoUnexpectedErrors() {
+            try {
+                if (!Errors.Expected) {
+                    Assert.IsEmpty(Errors.Entries,
+                        $"Test logged unexpected SpokeError.Log entries: {string.Join(" | ", Errors.Entries.Select(e => e.msg))}");
+                }
+            } finally {
+                Errors.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Captures entries written to the global SpokeError.Log sink, restoring the previous sink on dispose.
+    /// Call ExpectErrors() from a test that intends to log — it opts the test out of the
+    /// no-unexpected-errors teardown check (and marks the test, for the reader, as an error-path test).
+    /// </summary>
+    public sealed class CapturedErrors : IDisposable {
+        readonly Action<string, Exception> previous;
+        public List<(string msg, Exception ex)> Entries { get; } = new();
+        public bool Expected { get; private set; }
+
+        public CapturedErrors() {
+            previous = SpokeError.Log;
+            SpokeError.Log = (m, e) => Entries.Add((m, e));
+        }
+
+        public void ExpectErrors() => Expected = true;
+
+        public void Dispose() => SpokeError.Log = previous;
+    }
+}


### PR DESCRIPTION
Adds a test suite covering Spoke.Runtime and Spoke.Reactive. The `~` character in `Tests~` ensures the folder isn't seen by Unity. Tests are run outside of Unity with `dotnet test` inside the `Tests~` folder.

Fixes an re-entrancy issue when a docked epochs calls `Dock.Drop` on itself while it is running. Now detachment is deferred until after the epoch has popped from the stack.