### PR TITLE
Effect<T> returning null will default value

### DIFF
--- a/Spoke.Reactive/Effect.cs
+++ b/Spoke.Reactive/Effect.cs
@@ -33,7 +33,7 @@ namespace Spoke {
             if (result is ISignal<T> signal) {
                 s.Subscribe(signal, x => state.Set(x));
             }
-            s.Call(new LambdaEpoch("Deferred Initializer", s => s => state.Set(result.Now)));
+            s.Call(new LambdaEpoch("Deferred Initializer", s => s => state.Set(result != null ? result.Now : default)));
         };
 
         public SpokeHandle Subscribe(Action action) 

--- a/Tests~/ReactiveTests/EffectTests.cs
+++ b/Tests~/ReactiveTests/EffectTests.cs
@@ -268,5 +268,32 @@ namespace Spoke.Tests {
                 "Changing 'a' must cause exactly ONE re-run. Writing 'b' mid-run — before re-reading it — " +
                 "must not schedule a redundant second re-run.");
         }
+
+        [Test]
+        public void EffectT_BlockReturnsNull_ExposesDefault() {
+            var observed = -1;
+
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
+                var derived = s.Effect<int>(s => null);
+                s.Effect(s => observed = s.D(derived));
+            }));
+
+            Assert.AreEqual(0, observed);
+        }
+
+        [Test]
+        public void EffectT_BlockReturnsNullAfterValue_ResetsToDefault() {
+            var hasValue = State.Create(true);
+            var observed = -1;
+
+            using var tree = SpokeTree.Spawn(new Effect("root", s => {
+                var derived = s.Effect<int>(s => s.D(hasValue) ? s.Memo(s => 7) : null);
+                s.Effect(s => observed = s.D(derived));
+            }));
+            Assert.AreEqual(7, observed);
+
+            hasValue.Set(false);
+            Assert.AreEqual(0, observed);
+        }
     }
 }


### PR DESCRIPTION
When an `EffectBlock<T>` returns null, the resulting signal will be set to `default(T)`.
Previously it would have NRE'd