### PR TITLE
fix runtime tree oscillation guard

### DIFF
--- a/Spoke.Runtime/SpokeRuntime.cs
+++ b/Spoke.Runtime/SpokeRuntime.cs
@@ -119,16 +119,16 @@ namespace Spoke {
                     // The next tree would have been ordered before the prev, an oscillation has happened
                     passCount++;
                 }
+                prev = top;
 
                 // Tick the tree. SpokeTree always flushes in Auto mode
-                (this as Friend).TickTree(scheduledTrees.RemoveMin());
+                TickTree(scheduledTrees.RemoveMin());
             } while (HasPending());
         }
 
-        // Delivers a tick to the given tree.
-        // Sets the runtime's current flush layer to the tree's flush layer, and restores it afterwards.
-        // The runtime's flush layer determines whether TryFlush() flushes nested or not.
-        void Friend.TickTree(SpokeTree tree) {
+        // Delivers a tick to the given tree. Sets the runtime's current flush layer to the tree's
+        // flush layer (which determines whether TryFlush flushes nested), and restores it afterwards.
+        void TickTree(SpokeTree tree) {
             var storeLayer = layer;
             layer = Math.Min(tree.FlushLayer, layer);
             try {
@@ -137,6 +137,11 @@ namespace Spoke {
                 SpokeError.Log($"Uncaught Spoke error", e);
             }
             layer = storeLayer;
+        }
+
+        // Ticks a tree, then flushes anything scheduled during the tick.
+        void Friend.TickTree(SpokeTree tree) {
+            TickTree(tree);
             if (frames.Count == 0) {
                 TryFlush();
             }

--- a/Tests~/RuntimeTests/SpokeTreeTests.cs
+++ b/Tests~/RuntimeTests/SpokeTreeTests.cs
@@ -141,6 +141,22 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void OscillationGuard_StopsPingPong_BetweenSeparateTrees() {
+            Errors.ExpectErrors();
+            EpochPorts a = default, b = default;
+            var armed = false;
+
+            using var treeA = SpokeTree.Spawn(new LambdaEpoch(s => { a = s.Ports; return s => { if (armed) b.RequestTick(); }; }));
+            using var treeB = SpokeTree.Spawn(new LambdaEpoch(s => { b = s.Ports; return s => { if (armed) a.RequestTick(); }; }));
+
+            armed = true;
+            a.RequestTick(); // two trees re-arming each other across flushes
+
+            Assert.IsTrue(Errors.Entries.Exists(e => e.msg.Contains("oscillation limit")),
+                "Cross-tree ping-pong should be stopped by the oscillation guard");
+        }
+
+        [Test]
         public void Dispose_DuringFlush_IsDeferredUntilFlushCompletes() {
             // Disposing a tree from inside its own flush must NOT tear it down mid-tick — that would
             // pull the rug out from under the executing epoch. SpokeTree.Dispose defers the detach until


### PR DESCRIPTION
Spoke Runtime was supposed to have an oscillation guard in place, in case multiple SpokeTree ping pong between each other in a loop. As in, Tree A causes B to be scheduled, which causes A to be scheduled, and so on...

The guard wasn't working correctly. This has now been fixed.