### PR TITLE
Fix IsPlaying signal

### DIFF
--- a/Spoke.Unity/UnitySignals.cs
+++ b/Spoke.Unity/UnitySignals.cs
@@ -57,8 +57,8 @@ namespace Spoke {
                 Application.quitting += () => appTeardown.Invoke();
 #if UNITY_EDITOR
                 EditorApplication.playModeStateChanged += state => {
-                    isPlaying.Set(Application.isPlaying);
                     if (state == PlayModeStateChange.ExitingPlayMode) appTeardown.Invoke();
+                    isPlaying.Set(state == PlayModeStateChange.EnteredPlayMode);
                 };
                 AssemblyReloadEvents.beforeAssemblyReload += () => appTeardown.Invoke();
 #endif


### PR DESCRIPTION
Spoke provides a reactive signal `UnitySignals.IsPlaying` as convenient alternative to `Application.isPlaying`.
It's useful for `[ExecuteAlways]` Spoke behaviours, that might need to mount different behaviour depending if the editor is playing or not.

The problem was that on exiting play mode, some `[ExecuteAlways]` behaviours were enabling before the `IsPlaying` signal is changed to `false`. `IsPlaying` would be true, while `Application.isPlaying` was already false.

The fix was to be more strict when `IsPlaying` can be true. Specifically, its only set true when `PlayModeStateChanged.EnteredPlayMode` is fired.
`UnitySignals.IsPlaying` still doesn't match `Application.isPlaying` perfectly. As far as I can tell there's no callback for this precise moment. Now it won't incorrectly report we are playing when we're not. It sets `IsPlaying` to false slightly too early, instead of slightly too late.