### PR TITLE
No GC on dynamic deps churn

### DIFF
--- a/Docs/Topics/Performance.md
+++ b/Docs/Topics/Performance.md
@@ -9,7 +9,6 @@ This page shows how Spoke performs, in terms of CPU usage and GC allocations.
 - [Philosophy](#philosophy)
 - [Scenario 1: Flush Loop Stress Test](#scenario-1-flush-loop-stress-test)
 - [Scenario 2: Forcing GC](#scenario-2-forcing-gc)
-- [Scenario 3: Unstable Dynamic Dependencies](#scenario-3-unstable-dynamic-dependencies)
 - [Allocation Cheat Sheet](#allocation-cheat-sheet)
 
 ---
@@ -134,35 +133,11 @@ GC is allocated when tree branches are rebuilt. The allocation sources are:
 
 ---
 
-## Scenario 3: Unstable Dynamic Dependencies
-
-This is a subtle source of GC worth mentioning.
-
-```csharp
-s.Effect(s => {
-    if (s.D(cond1)) return;
-    if (s.D(cond2)) return;
-    DoSomething();
-});
-```
-
-Imagine this sequence:
-
-- On the first run, `cond1` is `false`, so only `cond1` is bound as a dependency.
-- On the second run, `cond1` is `true`, so `cond2` is bound for the first time.
-
-Between runs, the list of dynamic dependencies changes. For newly bound dependencies, Spoke allocates a small closure to track them, causing a small GC allocation.
-
-If the same dependencies are accessed in the same order across runs, Spoke reuses its previous setup and avoids any new allocations.
-
----
-
 ## Allocation Cheat Sheet
 
 Spoke allocates when you:
 
 - Call `State.Create`, `s.Memo`, `s.Effect`, or similar functions.
-- Change dynamic dependencies on rerun.
 
 It does **not** allocate when you:
 

--- a/Spoke.Reactive/Computation.cs
+++ b/Spoke.Reactive/Computation.cs
@@ -46,6 +46,7 @@ namespace Spoke {
         HashSet<ITrigger> seen = new HashSet<ITrigger>();
         List<(ITrigger t, SpokeHandle h)> staticHandles = new List<(ITrigger t, SpokeHandle h)>();
         List<(ITrigger t, SpokeHandle h)> dynamicHandles = new List<(ITrigger t, SpokeHandle h)>();
+        List<Action> slotCallbacks = new List<Action>();
         public int depIndex;
 
         public DependencyTracker(Action schedule) {
@@ -54,7 +55,8 @@ namespace Spoke {
 
         public void AddStatic(ITrigger trigger) {
             if (!seen.Add(trigger)) return;
-            staticHandles.Add((trigger, trigger.Subscribe(ScheduleFromIndex(-1))));
+            // Static dependencies are never stale; schedule directly
+            staticHandles.Add((trigger, trigger.Subscribe(schedule)));
         }
 
         public void BeginDynamic() {
@@ -91,9 +93,15 @@ namespace Spoke {
         }
 
         // Dependencies may fire while we're in the middle of refreshing them
-        // Constructs a closure to capture the index at the time of subscription
+        // The callback captures the slot index at the time of subscription
         // The index tells us if the dependency is valid or stale when it fires
-        Action ScheduleFromIndex(int index) 
-            => () => { if (index < depIndex) schedule(); }; 
+        // Callbacks are cached per slot, so rebinding a slot doesn't allocate
+        Action ScheduleFromIndex(int index) {
+            while (slotCallbacks.Count <= index) {
+                var i = slotCallbacks.Count;
+                slotCallbacks.Add(() => { if (i < depIndex) schedule(); });
+            }
+            return slotCallbacks[index];
+        }
     }
 }


### PR DESCRIPTION
Unstable dynamic dependencies in effects/memos no longer allocates.
The `DependencyTracker` pools the stale-checking closures, instead of creating them fresh.