### PR TITLE
SpokeRuntime owns tree boost state

### DIFF
--- a/Spoke.Runtime/SpokeRuntime.cs
+++ b/Spoke.Runtime/SpokeRuntime.cs
@@ -19,7 +19,7 @@ namespace Spoke {
             void Release();
             void Schedule(SpokeTree tree);
             void TickTree(SpokeTree tree);
-            void TryScopedLayerBoost(SpokeTree tree, Action onPopped);
+            void TryScopedLayerBoost(SpokeTree tree);
         }
 
         // Intended for this to become a ThreadStatic in the future. So trees can be driven on multiple threads.
@@ -44,8 +44,33 @@ namespace Spoke {
         /// <summary>Monotonically increasing timestamp, incremented on each stack frame pushed.</summary>
         public long TimeStamp { get; private set; }
 
+        // Flush-scheduling priority: same as SpokeTree.CompareTo, except boosted trees outrank
+        // unboosted trees of the same layer, so TryFlush's PeekMin sees a newly spawned tree ahead
+        // of older pending trees and can grant it a nested flush.
+        int SchedulingOrder(SpokeTree a, SpokeTree b) {
+            if (a.FlushLayer != b.FlushLayer) {
+                return a.FlushLayer.CompareTo(b.FlushLayer);
+            }
+            var aBoosted = IsBoosted(a);
+            var bBoosted = IsBoosted(b);
+            if (aBoosted != bBoosted) {
+                return aBoosted ? -1 : 1;
+            }
+            return a.CompareTo(b);
+        }
+
         // Priority queue of trees pending flush
-        Heap<SpokeTree> scheduledTrees = new((a, b) => a.CompareTo(b));
+        Heap<SpokeTree> scheduledTrees;
+
+        // Trees spawned in the current flush window, which may flush nested in equal flush layers
+        HashSet<SpokeTree> boostedTrees = new HashSet<SpokeTree>();
+
+        SpokeRuntime() {
+            scheduledTrees = new Heap<SpokeTree>(SchedulingOrder);
+        }
+
+        bool IsBoosted(SpokeTree tree)
+            => boostedTrees.Count > 0 && boostedTrees.Contains(tree);
 
         SpokePool<List<Action>> fnlPool = SpokePool<List<Action>>.Create(l => l.Clear());
         List<Frame> frames = new List<Frame>();
@@ -109,13 +134,13 @@ namespace Spoke {
                     break;
                 }
                 var top = scheduledTrees.PeekMin();
-                var isLayerBoosted = (top as SpokeTree.Friend).IsLayerBoosted();
+                var isLayerBoosted = IsBoosted(top);
                 // Newly spawned trees may flush nested inside trees of equal flush layer
                 if (isLayerBoosted && top.FlushLayer > layer) return;
                 // Or else it must have a higher priority flush layer for nested flush
                 else if (!isLayerBoosted && top.FlushLayer >= layer) return;
 
-                if (prev != null && prev.CompareTo(top) > 0) {
+                if (prev != null && SchedulingOrder(prev, top) > 0) {
                     // The next tree would have been ordered before the prev, an oscillation has happened
                     passCount++;
                 }
@@ -147,19 +172,16 @@ namespace Spoke {
             }
         }
 
-        void Friend.TryScopedLayerBoost(SpokeTree tree, Action onPopped) {
-            // Boosted trees only possible when we're already flushing and the incoming tree's
+        void Friend.TryScopedLayerBoost(SpokeTree tree) {
+            // Boosts are only possible when we're already flushing and the incoming tree's
             // FlushLayer has equal or greater priority than the currently flushing tree.
             // Smaller numbers are higher priority
-            var isPossible = Frames.Count > 0 && tree.FlushLayer <= layer;
-            if (!isPossible) {
-                onPopped();
-                return;
-            }
+            if (Frames.Count == 0 || tree.FlushLayer > layer) return;
             // Incoming tree may eager tick as many times as it wants, up until the frame it was
             // created in is popped from the stack.
+            boostedTrees.Add(tree);
             var topHandle = new Handle(this, frames.Count - 1, versions[versions.Count - 1]);
-            topHandle.OnPopSelf(onPopped);
+            topHandle.OnPopSelf(() => boostedTrees.Remove(tree));
         }
 
         bool HasPending() {

--- a/Spoke.Runtime/SpokeTree.cs
+++ b/Spoke.Runtime/SpokeTree.cs
@@ -39,8 +39,7 @@ namespace Spoke {
                 (this as Ticker.Friend).SetToManual();  // Stops me requesting ticks from Spoke runtime
             } else {
                 command = CommandKind.Flush;            // Auto trees always have command=Flush
-                isLayerBoosted = true;                  // Boosts flush layer priority inside creator's scope
-                (SpokeRuntime.Local as SpokeRuntime.Friend).TryScopedLayerBoost(this, () => isLayerBoosted = false);
+                (SpokeRuntime.Local as SpokeRuntime.Friend).TryScopedLayerBoost(this); // May flush nested in creator's scope
             }
 
             // Reflect the spawn on the virtual stack
@@ -139,11 +138,7 @@ namespace Spoke {
     /// <summary>
     /// Abstract base for the root ticker. 
     /// </summary>
-    public abstract class SpokeTree : Ticker, IDisposable, SpokeTree.Friend {
-
-        new internal interface Friend {
-            bool IsLayerBoosted();
-        }
+    public abstract class SpokeTree : Ticker, IDisposable {
 
         // Convenience spawners. See docs: Spawn (default), SpawnEager (higher priority), SpawnManual (user-driven).
         public static SpokeTree<T> Spawn<T>(T root, params object[] services) where T : Epoch
@@ -170,26 +165,18 @@ namespace Spoke {
         public int FlushLayer { get; protected set; }
 
         protected long TimeStamp = -1;      // capture of SpokeRuntime.Local.TimeStamp at spawn
-        protected bool isLayerBoosted;      // when true, may flush nested in equal flush layers
-
-        bool Friend.IsLayerBoosted()
-            => isLayerBoosted;
 
         /// <summary>
-        /// Defines ordering among trees when the runtime chooses who flushes next.
+        /// Defines the canonical order among trees (see Epoch.CompareTo).
         /// Rules:
         /// 1) FlushLayer: lower first (e.g., eager trees at -1 outrank default 0)
-        /// 2) Boosted bit: boosted trees are serviced before unboosted trees of the same layer
-        /// 3) TimeStamp: FIFO among equals
+        /// 2) TimeStamp: FIFO among equals
         /// </summary>
         public int CompareTo(SpokeTree other) {
             if (FlushLayer != other.FlushLayer) {
                 return FlushLayer.CompareTo(other.FlushLayer);
             }
-            if (isLayerBoosted == other.isLayerBoosted) {
-                return TimeStamp.CompareTo(other.TimeStamp);
-            }
-            return isLayerBoosted ? -1 : 1;
+            return TimeStamp.CompareTo(other.TimeStamp);
         }
 
         /// <summary>

--- a/Tests~/RuntimeTests/SpokeRuntimeTests.cs
+++ b/Tests~/RuntimeTests/SpokeRuntimeTests.cs
@@ -86,6 +86,27 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void CompareTo_OrdersBySpawnOrder_WhileSpawnedTreeIsBoosted() {
+            // The scheduling boost a nested-spawned tree gets must not affect CompareTo
+            SpokeTree<LambdaEpoch> inner = null;
+            var cmpDuringBoost = 0;
+            LambdaEpoch main = null;
+
+            main = new LambdaEpoch(s => s => {
+                if (inner != null) return;
+                inner = SpokeTree.Spawn("Inner", new LambdaEpoch(s => null));
+                cmpDuringBoost = (inner as Epoch).CompareTo(main);
+            });
+
+            using var outer = SpokeTree.Spawn("Outer", main);
+            try {
+                Assert.Greater(cmpDuringBoost, 0, "Inner spawned later, so it must order after Outer");
+            } finally {
+                inner?.Dispose();
+            }
+        }
+
+        [Test]
         public void NestedTreeSpawn_DuringFlush_FlushesNestedInScope() {
             var log = new List<string>();
             SpokeTree<LambdaEpoch> inner = null;


### PR DESCRIPTION
Tree boosting is now contained entirely in `SpokeRuntime`.

`Epoch.CompareTo(other)` and `SpokeTree.CompareTo(other)` now both have stable responses. Because they are not influenced by tree boosting behaviour.

Bit pedantic. Just making those `CompareTo` methods more semantically meaningful for the `Spoke.Heartbeat` addon.