### PR TITLE
Add try/catch to Dock.Call

### DIFF
--- a/Spoke.Runtime/Dock.cs
+++ b/Spoke.Runtime/Dock.cs
@@ -46,17 +46,22 @@ namespace Spoke {
             }
             // Push a stack frame to reflect the docking action
             (SpokeRuntime.Local as SpokeRuntime.Friend).Push(new(SpokeRuntime.FrameKind.Dock, this));
-            Drop(key);  // Detach existing epoch at the key, if any
-            // Sweep once the slots outgrow the packed coordinate range and at least half are reclaimable
-            if (childSlots.Count > 255 && slotByKey.Count * 2 <= childSlots.Count) {
-                (this as Friend).Compact();
+            try {
+                Drop(key);  // Detach existing epoch at the key, if any
+                // Sweep once the slots outgrow the packed coordinate range and at least half are reclaimable
+                if (childSlots.Count > 255 && slotByKey.Count * 2 <= childSlots.Count) {
+                    (this as Friend).Compact();
+                }
+                // Slot order matches attach order, so children tick ordered by attach-time
+                slotByKey.Add(key, childSlots.Count);
+                childSlots.Add(new(key, epoch));
+                var childTicker = (this as Epoch.Friend).GetTicker();
+                // The child is slotted before Attach, so if its Init throws it stays docked
+                // (faulted), and its partial cleanup still runs on Drop or dock detach.
+                (epoch as Epoch.Friend).Attach(this, childSlots.Count - 1, childTicker, null);
+            } finally {
+                (SpokeRuntime.Local as SpokeRuntime.Friend).Pop();
             }
-            // Slot order matches attach order, so children tick ordered by attach-time
-            slotByKey.Add(key, childSlots.Count);
-            childSlots.Add(new(key, epoch));
-            var childTicker = (this as Epoch.Friend).GetTicker();
-            (epoch as Epoch.Friend).Attach(this, childSlots.Count - 1, childTicker, null);
-            (SpokeRuntime.Local as SpokeRuntime.Friend).Pop();
             return epoch;
         }
 

--- a/Tests~/RuntimeTests/DockTests.cs
+++ b/Tests~/RuntimeTests/DockTests.cs
@@ -265,5 +265,36 @@ namespace Spoke.Tests {
 
             Assert.IsNotNull(caught, "Dock.Call during detaching should throw");
         }
+
+        [Test]
+        public void Call_ChildInitThrows_LeavesRuntimeStackBalanced() {
+            var log = new List<string>();
+            Dock dock = null;
+
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                dock = s.Call(new Dock());
+                return null;
+            }));
+
+            Assert.Throws<SpokeException>(() => dock.Call("k", new LambdaEpoch(s => {
+                s.OnCleanup(() => log.Add("partial-cleanup"));
+                throw new Exception("boom");
+            })));
+
+            Assert.AreEqual(0, SpokeRuntime.Frames.Count,
+                "the Dock frame must be popped even when the child's Init throws");
+
+            // The faulted child stays docked; replacing its key runs the cleanup it
+            // registered before throwing, and the dock keeps working
+            dock.Call("k", new LambdaEpoch(s => {
+                log.Add("replacement-attached");
+                return s => log.Add("replacement-tick");
+            }));
+            tree.Flush();
+
+            CollectionAssert.AreEqual(
+                new[] { "partial-cleanup", "replacement-attached", "replacement-tick" }, log);
+            Assert.IsNull(tree.Fault);
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug in `Dock.Call` where a docked epoch throws from its init block and caused the dock to leave behind its virtual call frame on the `SpokeRuntime` stack.

Now its wrapped in a try/catch, so the docks frame will be popped.