### PR TITLE
Dependants can ensure SpokeUnityBootstrap is initialized

### DIFF
--- a/Spoke.Unity/SpokeUnityBootstrap.cs
+++ b/Spoke.Unity/SpokeUnityBootstrap.cs
@@ -16,14 +16,14 @@ namespace Spoke {
 #if UNITY_EDITOR
     [InitializeOnLoad]
 #endif
-    internal static class SpokeUnityBootstrap {
+    public static class SpokeUnityBootstrap {
         static bool isInitialized;
 
-        static SpokeUnityBootstrap() 
-            => Init();
+        static SpokeUnityBootstrap()
+            => EnsureInitialized();
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
-        static void Init() {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        public static void EnsureInitialized() {
             if (isInitialized) return;
             isInitialized = true;
             SpokeError.Log = (msg, ex) => Debug.LogError($"[Spoke] {msg}\n{ex}");


### PR DESCRIPTION
`SpokeUnityBootstrap` runs in `[RuntimeInitializeLoadType.SubsystemRegistration]` and assigns the default Spoke logger to Unitys `Debug.Log`.

If a `SpokeTree` was spawned in another `SubsystemRegistration` hook then its possible it runs before the bootstrap. Any errors would be written to `Console.Log` instead of Unitys console.

This should be an extremely niche use case. The fix is to expose a method `SpokeUnityBootstrap.EnsureInitialized()` that can be called by dependants.