### PR TITLE
Improve performance for unsubscribing from trigger

### DIFF
--- a/Spoke.Reactive/Trigger.cs
+++ b/Spoke.Reactive/Trigger.cs
@@ -30,11 +30,11 @@ namespace Spoke {
         public struct Unit { }
 
         /// <summary>Creates a trigger without any event payload</summary>
-        public static Trigger Create() 
+        public static Trigger Create()
             => Create<Unit>();
 
         /// <summary>Creates a trigger with event payload of type T</summary>
-        public static Trigger<T> Create<T>() 
+        public static Trigger<T> Create<T>()
             => new Trigger<T>();
 
         /// <summary>Subscribes the trigger, ignoring payload, returns unsubscribe handle</summary>
@@ -60,30 +60,35 @@ namespace Spoke {
     /// Concrete implementation of Trigger with event payload of type T
     /// </summary>
     public sealed class Trigger<T> : Trigger, ITrigger<T> {
-        SpokePool<List<long>> longListPool = SpokePool<List<long>>.Create(l => l.Clear());
-        SpokePool<List<Subscription>> subListPool = SpokePool<List<Subscription>>.Create(l => l.Clear());
-        
+        static SpokePool<List<long>> longListPool = SpokePool<List<long>>.Create(l => l.Clear());
+
+        // Subscriptions in subscribe order. Unsubscribing tombstones a slot (nulling its action)
+        // rather than removing it; Compact() sweeps the tombstones out. Dispatches walk their own
+        // copy, so the slots are free to move at any time.
         List<Subscription> subs = new List<Subscription>();
-        Queue<T> events = new Queue<T>(); // Event queue in case of re-entrant invokes
+        List<Subscription> dispatchList;
+        int deadCount;
+
+        Queue<T> events = new Queue<T>();   // Event queue in case of re-entrant invokes
         Action<long> _unsub;
         Action _flush;
-        long idCount = 0; // Monotonically increasing id for subscriptions
+        long idCount = 0;   // Monotonically increasing id for subscriptions
         bool isFlushing;
 
         public Trigger() {
             // Capture Actions once to avoid allocations
             _unsub = Unsub;
-            _flush = Flush; 
+            _flush = Flush;
         }
 
         /// <summary>Subscribes the trigger, without taking payload, returns unsubscribe handle</summary>
         public override SpokeHandle Subscribe(Action action) {
-            return Subscribe(Subscription.Create(idCount++, action));
+            return Subscribe(new Subscription { Id = idCount++, Fn = action });
         }
 
         /// <summary>Subscribes the trigger, taking payload of type T, returns unsubscribe handle</summary>
         public SpokeHandle Subscribe(Action<T> action) {
-            return Subscribe(Subscription.Create(idCount++, action));
+            return Subscribe(new Subscription { Id = idCount++, Fn = action });
         }
 
         /// <summary>
@@ -95,9 +100,9 @@ namespace Spoke {
         }
 
         /// <summary>Invokes the trigger with event payload</summary>
-        public void Invoke(T param) { 
-            events.Enqueue(param); 
-            SpokeRuntime.Batch(_flush); 
+        public void Invoke(T param) {
+            events.Enqueue(param);
+            SpokeRuntime.Batch(_flush);
         }
 
         /// <summary>SpokeHandle.Dispose() is preferred, as it is more efficient</summary>
@@ -110,33 +115,42 @@ namespace Spoke {
             Unsub(action);
         }
 
-        // Flush the event queue, invoking all subscribers for each event
+        // Flush the event queue, dispatching each event to the subscribers
         void Flush() {
             if (isFlushing) return;
             isFlushing = true;
-            while (events.Count > 0) {
-                var evt = events.Dequeue();
-                // Copy subscribers, in case of modifications during invoke
-                var subList = subListPool.Get();
-                foreach (var sub in subs) {
-                    subList.Add(sub);
+            try {
+                while (events.Count > 0) {
+                    Dispatch(events.Dequeue());
                 }
-                foreach (var sub in subList) {
-                    try { 
-                        sub.Invoke(evt); 
-                    } catch (Exception ex) { 
-                        SpokeError.Log("Trigger subscriber error", ex); 
-                    }
-                }
-                subListPool.Return(subList);
+            } finally {
+                isFlushing = false;
+                Compact();
             }
-            isFlushing = false;
+        }
+
+        // Notify the subscribers the trigger had when the dispatch began. The copy fixes that set:
+        // anyone subscribing during the dispatch isn't notified this round, and anyone
+        // unsubscribing during it was still in the set, so is notified anyway.
+        void Dispatch(T evt) {
+            var subList = dispatchList ?? (dispatchList = new List<Subscription>());
+            subList.Clear();        // No-op unless the previous dispatch was cut short
+            subList.AddRange(subs); // Tombstones come along; their null action no-ops in Invoke
+            for (var i = 0; i < subList.Count; i++) {
+                try {
+                    subList[i].Invoke(evt);
+                } catch (Exception ex) {
+                    SpokeError.Log("Trigger subscriber error", ex);
+                }
+            }
+            subList.Clear(); // Also drops the copied action refs, so the copy retains nothing
         }
 
         void Unsub(Delegate action) {
             var idList = longListPool.Get();
-            foreach (var sub in subs) {
-                if (sub.Key == action) {
+            for (var i = 0; i < subs.Count; i++) {
+                var sub = subs[i];
+                if (sub.Fn == action) {
                     idList.Add(sub.Id);
                 }
             }
@@ -146,41 +160,53 @@ namespace Spoke {
             longListPool.Return(idList);
         }
 
+        // Ids ascend with slot order, so the slot can be found by binary search
         protected override void Unsub(long id) {
-            for (int i = 0; i < subs.Count; i++) {
-                if (subs[i].Id == id) { 
-                    subs.RemoveAt(i); 
-                    return; 
-                }
+            var lo = 0;
+            var hi = subs.Count - 1;
+            while (lo <= hi) {
+                var mid = (int)(((uint)lo + (uint)hi) >> 1);
+                var sub = subs[mid];
+                if (sub.Id < id) { lo = mid + 1; continue; }
+                if (sub.Id > id) { hi = mid - 1; continue; }
+                if (sub.Fn == null) return;   // Already unsubscribed
+                sub.Fn = null;  // An in-flight dispatch still holds its own copy
+                subs[mid] = sub;
+                deadCount++;
+                return;
             }
         }
 
+        // Sweep out the tombstoned slots, packing the survivors down
+        void Compact() {
+            // Not worth the walk until the tombstones outnumber the live slots
+            if (deadCount * 2 <= subs.Count) return;
+            var write = 0;
+            for (var read = 0; read < subs.Count; read++) {
+                if (subs[read].Fn == null) continue;
+                subs[write++] = subs[read];
+            }
+            subs.RemoveRange(write, subs.Count - write);
+            deadCount = 0;
+        }
+
         SpokeHandle Subscribe(Subscription sub) {
+            // Nothing else sweeps a trigger that gets subscribed and unsubscribed but never invoked
+            Compact();
             subs.Add(sub);
             return SpokeHandle.Of(sub.Id, _unsub);
         }
 
         // Internal representation of a subscription, either with or without payload
         struct Subscription {
-            public long Id; 
-            Action<T> ActionT; 
-            Action Action;
+            public long Id;
+            public Delegate Fn;     // Action<T> or Action. Null marks an unsubscribed slot
 
-            public static Subscription Create(long id, Action<T> action) {
-                return new Subscription { Id = id, ActionT = action };
-            }
-
-            public static Subscription Create(long id, Action action) {
-                return new Subscription { Id = id, Action = action };
-            }
-            
-            public Delegate Key => ActionT != null ? (Delegate)ActionT : Action;
-            
             public void Invoke(T arg) {
-                if (ActionT != null) {
-                    ActionT(arg);
-                } else {
-                    Action?.Invoke();
+                if (Fn is Action<T> withPayload) {
+                    withPayload(arg);
+                } else if (Fn is Action plain) {
+                    plain();
                 }
             }
         }

--- a/Spoke.Runtime/Dock.cs
+++ b/Spoke.Runtime/Dock.cs
@@ -10,7 +10,7 @@ namespace Spoke {
     public sealed class Dock : Epoch, Dock.Friend, Dock.Introspect {
 
         new internal interface Friend {
-            void Compact();
+            void Compact(bool reindexAll);
         }
 
         new internal interface Introspect {
@@ -48,9 +48,11 @@ namespace Spoke {
             (SpokeRuntime.Local as SpokeRuntime.Friend).Push(new(SpokeRuntime.FrameKind.Dock, this));
             try {
                 Drop(key);  // Detach existing epoch at the key, if any
-                // Sweep once the slots outgrow the packed coordinate range and at least half are reclaimable
-                if (childSlots.Count > 255 && slotByKey.Count * 2 <= childSlots.Count) {
-                    (this as Friend).Compact();
+                // Sweep once the slots outgrow the packed coordinate range and at least half are
+                // reclaimable. The incoming child takes index childSlots.Count, so this is the
+                // point where the next one stops being packable.
+                if (childSlots.Count > PackedTreeCoords128.MaxIndex && slotByKey.Count * 2 <= childSlots.Count) {
+                    (this as Friend).Compact(reindexAll: false);
                 }
                 // Slot order matches attach order, so children tick ordered by attach-time
                 slotByKey.Add(key, childSlots.Count);
@@ -80,15 +82,21 @@ namespace Spoke {
             if (slotByKey.Count == 0) childSlots.Clear();
         }
 
-        // Sweep out dropped slots, renumbering the survivors so new attachments pack again
-        void Friend.Compact() {
+        // Sweep out dropped slots, renumbering the survivors so new attachments pack again.
+        // Two callers, two jobs:
+        // - Attaching a child only shifts the survivors after a gap, so only they need reindexing.
+        //   Reindexing one is a walk of its whole subtree, so skipping the rest is worth it.
+        // - The dock's own coords moving invalidates every child's, moved or not: reindexAll.
+        void Friend.Compact(bool reindexAll) {
             var write = 0;
             for (var read = 0; read < childSlots.Count; read++) {
                 var slot = childSlots[read];
                 if (slot.Value == null) continue;
-                childSlots[write] = slot;
-                slotByKey[slot.Key] = write;
-                (slot.Value as Epoch.Friend).Reindex(write);
+                if (reindexAll || write != read) {
+                    childSlots[write] = slot;
+                    slotByKey[slot.Key] = write;
+                    (slot.Value as Epoch.Friend).Reindex(write);
+                }
                 write++;
             }
             childSlots.RemoveRange(write, childSlots.Count - write);

--- a/Spoke.Runtime/Epoch.cs
+++ b/Spoke.Runtime/Epoch.cs
@@ -148,7 +148,7 @@ namespace Spoke {
                 }
             }
             // Dock children live outside the attachment list; the dock renumbers them as it refreshes
-            if (this is Dock dock) (dock as Dock.Friend).Compact();
+            if (this is Dock dock) (dock as Dock.Friend).Compact(reindexAll: true);
         }
 
         // Attach-time initialization. Builds the initial attachment list and arms first tick.

--- a/Spoke.Runtime/PackedTreeCoords.cs
+++ b/Spoke.Runtime/PackedTreeCoords.cs
@@ -10,6 +10,15 @@ namespace Spoke {
     /// </summary>
     public readonly struct PackedTreeCoords128 : IComparable<PackedTreeCoords128> {
 
+        const int BitsPerIndex = 8;             // one byte per layer
+        const int LayersPerWord = 64 / BitsPerIndex;
+
+        /// <summary>Largest index a layer can encode. Extending past it yields Invalid.</summary>
+        public const int MaxIndex = (1 << BitsPerIndex) - 1;
+
+        /// <summary>Layers the coordinate can hold. Extending a full one yields Invalid.</summary>
+        public const int MaxDepth = LayersPerWord * 2;  // hi and lo
+
         public static PackedTreeCoords128 Invalid => new(0, 0, byte.MaxValue);
 
         readonly ulong hi; // top 8 levels
@@ -26,13 +35,15 @@ namespace Spoke {
 
         /// <summary>The coordinate one layer deeper, at index idx. Invalid if it doesn't fit.</summary>
         public PackedTreeCoords128 Extend(long idx) {
-            if (!IsValid || depth == 16 || idx < 0 || idx > 255) {
+            if (!IsValid || depth == MaxDepth || idx < 0 || idx > MaxIndex) {
                 return Invalid;
             }
-            if (depth < 8) {
-                return new(hi | ((ulong)idx << ((7 - depth) * 8)), lo, (byte)(depth + 1));
+            // Layers fill each word from its most significant byte down, so that comparing the
+            // words as integers compares the layers in order.
+            if (depth < LayersPerWord) {
+                return new(hi | ((ulong)idx << ((LayersPerWord - 1 - depth) * BitsPerIndex)), lo, (byte)(depth + 1));
             }
-            return new(hi, lo | ((ulong)idx << ((15 - depth) * 8)), (byte)(depth + 1));
+            return new(hi, lo | ((ulong)idx << ((MaxDepth - 1 - depth) * BitsPerIndex)), (byte)(depth + 1));
         }
 
         public int CompareTo(PackedTreeCoords128 other) {

--- a/Tests~/ReactiveTests/TriggerTests.cs
+++ b/Tests~/ReactiveTests/TriggerTests.cs
@@ -52,6 +52,41 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void Trigger_FiresInSubscriptionOrder_WithGapsFromUnsubscribes() {
+            var t = Trigger.Create();
+            var order = new List<int>();
+            var handles = new List<SpokeHandle>();
+            for (var i = 0; i < 200; i++) {
+                var n = i;
+                handles.Add(t.Subscribe(() => order.Add(n)));
+            }
+            for (var i = 0; i < 200; i += 2) handles[i].Dispose();
+
+            t.Invoke();
+
+            var expected = new List<int>();
+            for (var i = 1; i < 200; i += 2) expected.Add(i);
+            CollectionAssert.AreEqual(expected, order);
+            foreach (var h in handles) h.Dispose();
+        }
+
+        // Thousands of subscribe/unsubscribe pairs without an invoke between them
+        [Test]
+        public void Trigger_ChurnedWithoutInvoking_StillDeliversToLiveSubscribers() {
+            var t = Trigger.Create();
+            var hits = 0;
+            using var resident = t.Subscribe(() => hits++);
+            for (var i = 0; i < 5000; i++) {
+                var h = t.Subscribe(() => hits += 100);
+                h.Dispose();
+            }
+
+            t.Invoke();
+
+            Assert.AreEqual(1, hits);
+        }
+
+        [Test]
         public void TriggerT_SubscribeWithPayload_ReceivesPayload() {
             var t = Trigger.Create<int>();
             var seen = -1;
@@ -120,6 +155,74 @@ namespace Spoke.Tests {
             t.Invoke();  // Now both fire
             Assert.AreEqual(3, calls);
             lateSub.Dispose();
+        }
+
+        // The subscriber set is fixed when the dispatch begins. One that an earlier subscriber
+        // unsubscribes mid-dispatch was still in that set, so it fires.
+        [Test]
+        public void Trigger_UnsubscribeDuringInvoke_StillFiresThisRound() {
+            var t = Trigger.Create();
+            var lateFired = 0;
+            SpokeHandle second = default;
+            using var first = t.Subscribe(() => second.Dispose());
+            second = t.Subscribe(() => lateFired++);
+
+            t.Invoke();
+            Assert.AreEqual(1, lateFired);
+
+            t.Invoke();
+            Assert.AreEqual(1, lateFired, "must not fire again on later events");
+        }
+
+        // Unsubscribing during one event still removes the subscriber from the events after it,
+        // including ones already queued by a re-entrant invoke.
+        [Test]
+        public void Trigger_UnsubscribedDuringEarlierEvent_DoesNotFireOnQueuedEvent() {
+            var t = Trigger.Create<int>();
+            var seen = new List<int>();
+            SpokeHandle victim = default;
+            var calls = 0;
+            using var driver = t.Subscribe((int v) => {
+                calls++;
+                if (calls == 1) {
+                    t.Invoke(99);      // queued, dispatched once this one completes
+                    victim.Dispose();
+                }
+            });
+            victim = t.Subscribe((int v) => seen.Add(v));
+
+            t.Invoke(1);
+
+            CollectionAssert.AreEqual(new[] { 1 }, seen);
+        }
+
+        // A subscriber is allowed to unsubscribe others and to subscribe, both while the trigger
+        // is dispatching. The set fixed at dispatch start still gets exactly one call each: the
+        // mass-unsubscribed still fire this round, the mid-dispatch addition doesn't.
+        [Test]
+        public void Trigger_MassUnsubscribeThenSubscribe_DuringDispatch_DeliversToDispatchStartSet() {
+            var t = Trigger.Create();
+            var handles = new List<SpokeHandle>();
+            var survivorsFired = 0;
+            var addedFired = 0;
+
+            // The first subscriber tears down most of the list, then subscribes, all mid-dispatch
+            var first = t.Subscribe(() => {
+                for (var i = 100; i < handles.Count; i++) handles[i].Dispose();
+                handles.Add(t.Subscribe(() => addedFired++));
+            });
+
+            for (var i = 0; i < 1000; i++) {
+                handles.Add(t.Subscribe(() => survivorsFired++));
+            }
+
+            t.Invoke();
+
+            Assert.AreEqual(1000, survivorsFired, "everyone in the dispatch-start set fires, unsubscribed or not");
+            Assert.AreEqual(0, addedFired, "subscribed mid-dispatch, so not in the set");
+
+            first.Dispose();
+            foreach (var h in handles) h.Dispose();
         }
 
         [Test]

--- a/Tests~/RuntimeTests/DockTests.cs
+++ b/Tests~/RuntimeTests/DockTests.cs
@@ -222,6 +222,42 @@ namespace Spoke.Tests {
                 "inner children tick before their parents, parents tick in attach order");
         }
 
+        // A dock's children extend from the dock's own tree-coords. When an outer dock sweeps and
+        // moves an inner dock to a new slot, the inner dock's children have to pick up the new
+        // coords. Everything here stays inside the 256-per-layer packed range, where a stale
+        // coordinate still reads as valid instead of falling back to the parent-chain walk.
+        [Test]
+        public void NestedDock_ChildrenKeepCorrectOrder_AfterOuterDockSweeps() {
+            Dock outer = null;
+            using var tree = SpokeTree.SpawnManual(new LambdaEpoch(s => {
+                outer = s.Call(new Dock());
+                return null;
+            }));
+
+            for (var i = 0; i < 250; i++) outer.Call($"filler{i}", new LambdaEpoch(s => null));
+
+            Dock inner = null;
+            outer.Call("innerHost", new LambdaEpoch(s => {
+                inner = s.Call(new Dock());
+                return null;
+            }));
+            var innerChild = inner.Call("c", new LambdaEpoch(s => null));
+            var neighbour = outer.Call("neighbour", new LambdaEpoch(s => null));
+
+            Assert.Less(innerChild.CompareTo(neighbour), 0, "starts ordered before the neighbour");
+
+            // Take the slot count past 255 so the dock is willing to sweep, then empty it out
+            for (var i = 0; i < 6; i++) outer.Call($"extra{i}", new LambdaEpoch(s => null));
+            for (var i = 0; i < 250; i++) outer.Drop($"filler{i}");
+            for (var i = 0; i < 6; i++) outer.Drop($"extra{i}");
+
+            // Triggers the sweep, moving innerHost and neighbour down to low slots
+            outer.Call("trigger", new LambdaEpoch(s => null));
+
+            Assert.Less(innerChild.CompareTo(neighbour), 0,
+                "the inner dock's child must still sort before the neighbour");
+        }
+
         [Test]
         public void DockCleanup_DetachesChildren_InReverseAttachOrder() {
             var log = new List<string>();

--- a/Tests~/RuntimeTests/PackedTreeCoordsTests.cs
+++ b/Tests~/RuntimeTests/PackedTreeCoordsTests.cs
@@ -46,6 +46,26 @@ namespace Spoke.Tests {
             }
         }
 
+        // The first layers pack into one word and the rest into a second, so ordering has to hold
+        // within each word and across the seam between them.
+        [Test]
+        public void Compare_OrdersCorrectly_AcrossBothPackedWords() {
+            // Diverging at a deep layer, well past the seam
+            var a = Path(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0);
+            var b = Path(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 1);
+            Assert.Less(a.CompareTo(b), 0);
+
+            // A divergence in an early layer outranks anything deeper
+            var early = Path(0, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9);
+            var late = Path(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+            Assert.Less(early.CompareTo(late), 0);
+
+            // A coord sorts before one that extends it, including right at the seam
+            var atSeam = Path(1, 1, 1, 1, 1, 1, 1, 1);
+            Assert.Less(atSeam.CompareTo(atSeam.Extend(0)), 0);
+            Assert.Less(atSeam.Extend(0).CompareTo(atSeam.Extend(1)), 0);
+        }
+
         [Test]
         public void Extend_UsesFullCapacity_ThenYieldsInvalid() {
             var deep = default(PackedTreeCoords128);
@@ -63,6 +83,12 @@ namespace Spoke.Tests {
         [Test]
         public void Extend_OfInvalid_StaysInvalid() {
             Assert.IsFalse(PackedTreeCoords128.Invalid.Extend(0).IsValid);
+        }
+
+        static PackedTreeCoords128 Path(params long[] indices) {
+            var coord = default(PackedTreeCoords128);
+            foreach (var i in indices) coord = coord.Extend(i);
+            return coord;
         }
     }
 }


### PR DESCRIPTION
Unsubscribing from a `Trigger` was doing a linear scan over the subscription list and then a `List.RemoveAt`.
This was fine for triggers with only a handful of subscriptions (majority use case in Spoke).
But its pretty slow for triggers with hundreds or thousands of subscribers... For example `UnitySignals.AppTeardown` which is subscribed by every `SpokeBehaviour`.

Optimisations:
- Linear scan replaced with binary search, finding the subscription index to remove.
- Subscriptions are tombstoned instead of doing a `List.RemoveAt(i)`. When a certain ratio of tombstone/live subscriptions exist, the trigger compacts the list to remove all tombstones.

A couple of other tweaks and changes to `Dock` and `PackedTreeCoords128` are included too. Not really related to this PR, just happened to be in my working tree..