### PR TITLE
Remove SpokeException SkipMarkFaulted

### DIFF
--- a/Spoke.Runtime/Epoch.cs
+++ b/Spoke.Runtime/Epoch.cs
@@ -167,11 +167,7 @@ namespace Spoke {
                 tickIndex = attachEvents.Count;
                 tickCursor = coords.Extend(tickIndex);
             } catch (Exception e) {
-                if (e is SpokeException se) {
-                    if (!se.SkipMarkFaulted) Fault = se;
-                    se.SkipMarkFaulted = false;
-                    throw;
-                }
+                if (e is SpokeException se) throw Fault = se;
                 throw Fault = new SpokeException("Uncaught Exception in Init", e);
             } finally {
                 (SpokeRuntime.Local as SpokeRuntime.Friend).Pop();
@@ -194,11 +190,7 @@ namespace Spoke {
             try {
                 tickBlock?.Invoke(new EpochBuilder(new EpochMutations(this)));
             } catch (Exception e) {
-                if (e is SpokeException se) {
-                    if (!se.SkipMarkFaulted) Fault = se;
-                    se.SkipMarkFaulted = false;
-                    throw;
-                }
+                if (e is SpokeException se) throw Fault = se;
                 throw Fault = new SpokeException("Uncaught Exception in Tick", e);
             } finally {
                 (SpokeRuntime.Local as SpokeRuntime.Friend).Pop();

--- a/Spoke.Runtime/SpokeException.cs
+++ b/Spoke.Runtime/SpokeException.cs
@@ -13,7 +13,6 @@ namespace Spoke {
         // stack trace, and a weakref to the epoch.
         List<SpokeRuntime.Frame> stackSnapshot = new List<SpokeRuntime.Frame>();
         string innerTrace;
-        public bool SkipMarkFaulted; // Epochs may toggle this and rethrow, to avoid marking themselves as faulted.
 
         public ReadOnlyList<SpokeRuntime.Frame> StackSnapshot => new(stackSnapshot);
 

--- a/Tests~/RuntimeTests/FaultTests.cs
+++ b/Tests~/RuntimeTests/FaultTests.cs
@@ -75,26 +75,5 @@ namespace Spoke.Tests {
             Assert.Greater(faulty.Fault.StackSnapshot.Count, 0,
                 "Stack snapshot should contain frames captured at fault time");
         }
-
-        [Test]
-        public void SkipMarkFaulted_PreventsMarkingThatLayer_ButLetsPropagationContinue() {
-            Errors.ExpectErrors();
-            var childFaulty = new LambdaEpoch(s => throw new Exception("child-boom"));
-            var middle = new LambdaEpoch(s => {
-                try {
-                    s.Call(childFaulty);
-                } catch (SpokeException se) {
-                    se.SkipMarkFaulted = true;
-                    throw;
-                }
-                return null;
-            });
-
-            using var tree = SpokeTree.SpawnManual(middle);
-
-            Assert.IsNotNull(childFaulty.Fault, "Inner epoch should be faulted");
-            Assert.IsNull(middle.Fault, "Middle with SkipMarkFaulted=true should NOT be marked faulted");
-            Assert.IsNotNull(tree.Fault, "Tree should still be marked (SkipMarkFaulted resets after one layer)");
-        }
     }
 }


### PR DESCRIPTION
`SpokeException.SkipMarkFaulted` let exceptions bubble up through epochs without marking chosen epochs as faulted...

Removing for now because I didn't see a use case for it. Custom tickers are able to stop exceptions propagating already, so I'm not sure if `SkipMarkFaulted` has a genuine use case.