### PR TITLE
Improve computation performance

### DIFF
--- a/Spoke.Reactive/Computation.cs
+++ b/Spoke.Reactive/Computation.cs
@@ -40,34 +40,28 @@ namespace Spoke {
     }
 
     // Manages dynamic trigger subscriptions for a Computation
+    // Dependencies are matched to slots by position, so a run that reads the same dependencies in
+    // the same order rebinds nothing. Reading one twice simply takes two slots
     internal class DependencyTracker : IDisposable {
         Action schedule;
-        HashSet<ITrigger> seen = new HashSet<ITrigger>();
-        List<(ITrigger t, SpokeHandle h)> staticHandles = new List<(ITrigger t, SpokeHandle h)>();
+        List<SpokeHandle> staticHandles = new List<SpokeHandle>();
         List<(ITrigger t, SpokeHandle h)> dynamicHandles = new List<(ITrigger t, SpokeHandle h)>();
         List<Action> slotCallbacks = new List<Action>();
-        public int depIndex;
+        int depIndex;
 
         public DependencyTracker(Action schedule) {
             this.schedule = schedule;
         }
 
         public void AddStatic(ITrigger trigger) {
-            if (!seen.Add(trigger)) return;
-            // Static dependencies are never stale; schedule directly
-            staticHandles.Add((trigger, trigger.Subscribe(schedule)));
+            staticHandles.Add(trigger.Subscribe(schedule));
         }
 
         public void BeginDynamic() {
             depIndex = 0;
-            seen.Clear();
-            foreach (var dep in staticHandles) {
-                seen.Add(dep.t);
-            } 
         }
 
         public void AddDynamic(ITrigger trigger) {
-            if (!seen.Add(trigger)) return;
             if (depIndex >= dynamicHandles.Count) {
                 dynamicHandles.Add((trigger, trigger.Subscribe(ScheduleFromIndex(depIndex))));
             } else if (dynamicHandles[depIndex].t != trigger) {
@@ -85,8 +79,7 @@ namespace Spoke {
         }
 
         public void Dispose() {
-            seen.Clear();
-            foreach (var handle in staticHandles) handle.h.Dispose();
+            foreach (var handle in staticHandles) handle.Dispose();
             foreach (var handle in dynamicHandles) handle.h.Dispose();
             staticHandles.Clear(); dynamicHandles.Clear();
         }

--- a/Tests~/ReactiveTests/EffectTests.cs
+++ b/Tests~/ReactiveTests/EffectTests.cs
@@ -270,6 +270,56 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void Effect_ReadsSameSignalTwice_ReRunsOnce() {
+            // Repeat reads of a signal aren't deduped, but the effect still re-runs exactly once per
+            // change: a re-run is scheduled, not counted.
+            var a = State.Create(0);
+            var runs = 0;
+
+            using var tree = SpokeTree.Spawn(new Effect("twice", s => {
+                _ = s.D(a);
+                _ = s.D(a);
+                runs++;
+            }));
+            Assert.AreEqual(1, runs, "sanity: exactly one run on mount");
+
+            a.Set(1);
+            Assert.AreEqual(2, runs, "Two reads of the same signal must still produce ONE re-run");
+
+            a.Set(2);
+            Assert.AreEqual(3, runs);
+        }
+
+        [Test]
+        public void Effect_DependencyReadOrderFlips_BothStayLive() {
+            // Dependencies are re-established in read order on each run, so flipping the order
+            // re-subscribes them. Both signals must still re-run the effect afterwards.
+            var flip = State.Create(false);
+            var a = State.Create(0);
+            var b = State.Create(0);
+            var runs = 0;
+
+            using var tree = SpokeTree.Spawn(new Effect("order", s => {
+                runs++;
+                if (s.D(flip)) {
+                    _ = s.D(a); _ = s.D(b);
+                } else {
+                    _ = s.D(b); _ = s.D(a);
+                }
+            }));
+            Assert.AreEqual(1, runs, "sanity: exactly one run on mount");
+
+            flip.Set(true);
+            Assert.AreEqual(2, runs);
+
+            a.Set(1);
+            Assert.AreEqual(3, runs, "'a' must still be live after the read order flipped");
+
+            b.Set(1);
+            Assert.AreEqual(4, runs, "'b' must still be live after the read order flipped");
+        }
+
+        [Test]
         public void EffectT_BlockReturnsNull_ExposesDefault() {
             var observed = -1;
 


### PR DESCRIPTION
Some tweaks to the `DependencyTracker` class (used by all reactive objects) to optimise how Spoke manages static/dynamic dependencies.

This class was using a `HashSet` to dedup dependencies in case they were subscribed multiple times.
But in reality, Spoke has no problem with duplicate dependencies. The computation won't double-fire.

Removing the `HashSet` and deduplication guard speeds up Spoke by roughly 10% - 20%.