### PR TITLE
Remove internal lambdas from memo & phase

### DIFF
--- a/Spoke.Reactive/Memo.cs
+++ b/Spoke.Reactive/Memo.cs
@@ -12,22 +12,18 @@ namespace Spoke {
     public class Memo<T> : Computation, ISignal<T> {
         State<T> state = State.Create<T>();
         Action<ITrigger> _addDynamicTrigger;
-        Action<MemoBuilder> block;
+        MemoBlock<T> selector;
 
         public T Now => state.Now;
 
         public Memo(string name, MemoBlock<T> selector, params ITrigger[] triggers) : base(name, triggers) {
-            block = s => {
-                if (selector != null) {
-                    state.Set(selector(s));
-                }
-            };
+            this.selector = selector;
             _addDynamicTrigger = AddDynamicTrigger;
         }
 
         protected override void OnRun(EpochBuilder s) {
-            var builder = new MemoBuilder(_addDynamicTrigger, s);
-            block(builder);
+            if (selector == null) return;
+            state.Set(selector(new MemoBuilder(_addDynamicTrigger, s)));
         }
 
         public SpokeHandle Subscribe(Action action) 

--- a/Spoke.Reactive/Phase.cs
+++ b/Spoke.Reactive/Phase.cs
@@ -8,17 +8,17 @@ namespace Spoke {
 
         public Phase(string name, ISignal<bool> mountWhen, EffectBlock block, params ITrigger[] triggers) : base(name, triggers) {
             this.mountWhen = mountWhen;
-            this.block = s => {
-                if (mountWhen.Now) {
-                    block?.Invoke(s);
-                }
-            };
+            this.block = block;
         }
 
         protected override TickBlock Init(EpochBuilder s) {
             var mountBlock = base.Init(s);
             AddStaticTrigger(mountWhen);
             return mountBlock;
+        }
+
+        protected override void OnRun(EpochBuilder s) {
+            if (mountWhen.Now) base.OnRun(s);
         }
     }
 }


### PR DESCRIPTION
`Memo` and `Phase` were both constructing an internal lambda for when they're ticked. But there was no need, and it's an unnecessary allocation.
Removing the lambda and running their logic in the `OnRun` method instead.
Gives a very small performance boost, and reduces GC.