### PR TITLE
Reactify ReadOnlyList

### DIFF
--- a/Examples/05_BaseDefence/Scripts/Spatial/CollisionWorld.cs
+++ b/Examples/05_BaseDefence/Scripts/Spatial/CollisionWorld.cs
@@ -19,8 +19,9 @@ namespace Spoke.Examples.BaseDefence {
     //  // Sensor: detects colliders, but is itself undetectable.
     //  var sensor = world.AddSensor(() => new Circle(pos, range));
     //
-    //  // Overlaps: what it touches now, nearest-first.
-    //  foreach (var hit in sensor.Overlaps) hit.Owner.TakeDamage();
+    //  // Overlaps: a signal of what it touches now, nearest-first.
+    //  foreach (var hit in sensor.Overlaps.Now) hit.Owner.TakeDamage();
+    //  s.Effect(s => { foreach (var hit in s.D(sensor.Overlaps)) ... });   // reactive read
     //
     //  world.Tick();                                        // re-sample positions, refresh overlaps (call each frame)
     //  var hits = world.Query(new Circle(pos, radius));     // one-off lookup, all colliders overlapping circle
@@ -30,10 +31,8 @@ namespace Spoke.Examples.BaseDefence {
     public interface ISensor<T> : IDisposable {
         /// <summary>The circle this sensor currently occupies.</summary>
         Circle Circle { get; }
-        /// <summary>Colliders currently overlapping, sorted nearest-first.</summary>
-        ReadOnlyList<ICollider<T>> Overlaps { get; }
-        /// <summary>Fires when the set of Overlaps changes.</summary>
-        ITrigger OverlapsChanged { get; }
+        /// <summary>A signal of the colliders currently overlapping, sorted nearest-first.</summary>
+        ISignal<ReadOnlyList<ICollider<T>>> Overlaps { get; }
     }
 
     /// <summary>A detectable circle, bound to the owner it stands in for.</summary>
@@ -68,7 +67,7 @@ namespace Spoke.Examples.BaseDefence {
         public ICollider<T> AddCollider(T owner, Func<Circle> getCircle, Func<T, bool> filter = null)
             => new Body(this, owner, getCircle, detectable: true, filter);
 
-        /// <summary>Syncs collider/sensor positions, calculates overlaps, and fires OverlapsChanged where they changed</summary>
+        /// <summary>Syncs collider/sensor positions, calculates overlaps, and publishes Overlaps where they changed</summary>
         public void Tick() => SpokeRuntime.Batch(step);
 
         /// <summary>One-off immediate lookup of colliders overlapping area.</summary>
@@ -130,12 +129,12 @@ namespace Spoke.Examples.BaseDefence {
 
             public T Owner { get; }
             public Circle Circle => circle;
-            public ReadOnlyList<ICollider<T>> Overlaps => new(overlaps);
-            public ITrigger OverlapsChanged => changed;
+            public ISignal<ReadOnlyList<ICollider<T>>> Overlaps => overlapsState;
 
             public readonly bool detectable;
-            readonly Trigger changed = Trigger.Create();
+            readonly State<ReadOnlyList<ICollider<T>>> overlapsState = new();
             readonly List<ICollider<T>> overlaps = new();
+            long version;
             readonly List<(Body body, float dist2)> sorted = new();
             readonly Func<Circle> getCircle;
             readonly Func<T, bool> filter;
@@ -179,7 +178,8 @@ namespace Spoke.Examples.BaseDefence {
                 if (Same()) return;
                 overlaps.Clear();
                 foreach (var s in sorted) overlaps.Add(s.body);
-                changed.Invoke();
+                // Same list every publish; the bumped version makes each generation compare unequal
+                overlapsState.Set(new ReadOnlyList<ICollider<T>>(overlaps, ++version));
             }
 
             bool Same() {

--- a/Examples/05_BaseDefence/Scripts/Spatial/CollisionWorld.cs
+++ b/Examples/05_BaseDefence/Scripts/Spatial/CollisionWorld.cs
@@ -11,7 +11,7 @@ namespace Spoke.Examples.BaseDefence {
     // custom collision engine was simple to write.
     //
     // ----------------------------------------------------------------------------------------
-    //  var world = new CollisionWorld<Building>();          // owners are type T
+    //  var world = new CollisionWorld<Building>();          // owners are type Building
     //
     //  // Collider: a detectable circle, bound to an owner. Re-sampled each tick.
     //  var collider = world.AddCollider(building, () => new Circle(pos, radius));

--- a/Examples/05_BaseDefence/Scripts/UI/BoardInteractions.cs
+++ b/Examples/05_BaseDefence/Scripts/UI/BoardInteractions.cs
@@ -62,10 +62,11 @@ namespace Spoke.Examples.BaseDefence {
                 hoveringCircle.Set(default);
             });
             s.Effect(s => {
-                var overlap = sensor.Overlaps.Count > 0 ? sensor.Overlaps[0] : null;
+                var overlaps = s.D(sensor.Overlaps);
+                var overlap = overlaps.Count > 0 ? overlaps[0] : null;
                 hovering.Set(overlap?.Owner.GetComponent<IHoverable>());
                 hoveringCircle.Set(overlap?.Circle ?? default);
-            }, sensor.OverlapsChanged);
+            });
         };
 
         EffectBlock ShowHovered => s => {
@@ -100,8 +101,7 @@ namespace Spoke.Examples.BaseDefence {
 
             var groundSensor = s.Use(GameState.GroundZone.AddSensor(() => footprint.Now));
             var powerSensor = s.Use(GameState.PowerZone.AddSensor(() => new Circle(mousePos.Now, 0f), body => body.IsProvider));
-            var isValid = s.Memo(s => groundSensor.Overlaps.Count == 0 && powerSensor.Overlaps.Count > 0,
-                groundSensor.OverlapsChanged, powerSensor.OverlapsChanged);
+            var isValid = s.Memo(s => s.D(groundSensor.Overlaps).Count == 0 && s.D(powerSensor.Overlaps).Count > 0);
             var colour = s.Memo(s => s.D(isValid) ? s.D(validPlacementColour) : s.D(invalidPlacementColour));
             
             s.Effect(CoverageDisplay.Draw(footprint, colour, lineMaterial));

--- a/Examples/05_BaseDefence/Scripts/UI/CoverageDisplay.cs
+++ b/Examples/05_BaseDefence/Scripts/UI/CoverageDisplay.cs
@@ -18,9 +18,9 @@ namespace Spoke.Examples.BaseDefence {
             var sensor = s.Use(zone.AddSensor(() => GameState.View.Now.GroundArea, filter));
             var circles = s.Memo(s => {
                 var list = new List<Circle>();
-                foreach (var collider in sensor.Overlaps) list.Add(collider.Circle);
+                foreach (var collider in s.D(sensor.Overlaps)) list.Add(collider.Circle);
                 return list;
-            }, sensor.OverlapsChanged);
+            });
             s.Effect(DrawCircles(circles, colour, material));
         };
 

--- a/Examples/05_BaseDefence/Scripts/Units/Buildings/PowerNode.cs
+++ b/Examples/05_BaseDefence/Scripts/Units/Buildings/PowerNode.cs
@@ -86,10 +86,10 @@ namespace Spoke.Examples.BaseDefence {
                 var parentNow = s.D(parent);
                 if (parentNow == null) return;
                 s.Effect(s => {
-                    foreach (var c in collider.Overlaps)
+                    foreach (var c in s.D(collider.Overlaps))
                         if (c.Owner.Node == parentNow) return;
                     parent.Set(null);
-                }, collider.OverlapsChanged);
+                });
                 s.Effect(s => {
                     if (!s.D(parentNow.HasPower)) parent.Set(null);
                 });
@@ -116,7 +116,7 @@ namespace Spoke.Examples.BaseDefence {
 
             var isRootConnected = s.Memo(s => s.D(chain).isRootConnected);
             s.Phase(isRootConnected, s => {
-                foreach (var c in collider.Overlaps) {
+                foreach (var c in s.D(collider.Overlaps)) {
                     var node = c.Owner.Node;
                     if (node == this || node.isRoot) continue;
                     var canConnect = s.Memo(s => {
@@ -131,7 +131,7 @@ namespace Spoke.Examples.BaseDefence {
                     });
                     s.Phase(canConnect, s => node.parent.Set(this));
                 }
-            }, collider.OverlapsChanged);
+            });
         };
 
         void OnDrawGizmosSelected() {

--- a/Examples/05_BaseDefence/Scripts/Units/Buildings/Repair.cs
+++ b/Examples/05_BaseDefence/Scripts/Units/Buildings/Repair.cs
@@ -54,17 +54,17 @@ namespace Spoke.Examples.BaseDefence {
                     patient.Set(null);
                     return;
                 }
-                foreach (var c in sensor.Overlaps) {
+                foreach (var c in s.D(sensor.Overlaps)) {
                     if (c.Owner == patientNow.gameObject) return;
                 }
                 patient.Set(null);
-            }, sensor.OverlapsChanged);
+            });
 
             s.Effect(s => {
                 if (s.D(patient) != null) return;
                 Health best = null;
                 var bestFrac = 1f;
-                foreach (var c in sensor.Overlaps) {
+                foreach (var c in s.D(sensor.Overlaps)) {
                     if (c.Owner == building.gameObject) continue;
                     if (!c.Owner.TryGetComponent<Health>(out var health)) continue;
                     var frac = s.D(health.HPFraction);
@@ -74,7 +74,7 @@ namespace Spoke.Examples.BaseDefence {
                     }
                 }
                 patient.Set(best);
-            }, sensor.OverlapsChanged);
+            });
 
             return patient;
         };

--- a/Examples/05_BaseDefence/Scripts/Units/Buildings/Turret.cs
+++ b/Examples/05_BaseDefence/Scripts/Units/Buildings/Turret.cs
@@ -48,10 +48,10 @@ namespace Spoke.Examples.BaseDefence {
                 // Overlaps are nearest-first, so this picks the closest radar-revealed enemy.
                 var sensor = s.Use(GameState.EnemyZone.AddSensor(() => new Circle(transform.position, range)));
                 var target = s.Memo(s => {
-                    foreach (var c in sensor.Overlaps)
+                    foreach (var c in s.D(sensor.Overlaps))
                         if (s.D(c.Owner.IsTracked)) return c.Owner;
                     return null;
-                }, sensor.OverlapsChanged);
+                });
 
                 s.Effect(s => {
                     var targetNow = s.D(target);

--- a/Examples/05_BaseDefence/Scripts/Units/Enemies/Enemy.cs
+++ b/Examples/05_BaseDefence/Scripts/Units/Enemies/Enemy.cs
@@ -147,7 +147,7 @@ namespace Spoke.Examples.BaseDefence {
 
             s.Coroutine(() => {
                 var push = Vector3.zero;
-                foreach (var c in sensor.Overlaps) {
+                foreach (var c in sensor.Overlaps.Now) {
                     if (c.Owner == this) continue;
                     var away = transform.position - c.Owner.transform.position;
                     away.y = 0f;
@@ -163,7 +163,7 @@ namespace Spoke.Examples.BaseDefence {
         EffectBlock RadarTrack => s => {
             var sensor = s.Use(GameState.RadarZone.AddSensor(() => new Circle(transform.position, radius)));
 
-            var isTracked = s.Memo(s => sensor.Overlaps.Count > 0, sensor.OverlapsChanged);
+            var isTracked = s.Memo(s => s.D(sensor.Overlaps).Count > 0);
             s.Phase(isTracked, s => {
                 tracked.Set(true);
                 s.OnCleanup(() => tracked.Set(false));

--- a/Spoke.Runtime/ReadOnlyList.cs
+++ b/Spoke.Runtime/ReadOnlyList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Spoke {
@@ -5,18 +6,41 @@ namespace Spoke {
     /// <summary>
     /// A struct that wraps a List<T> and provides a read-only interface.
     /// It can be used in foreach loops without allocating.
+    /// Read-only, not immutable: the owner may still mutate the wrapped list.
+    /// Two wrappers are equal when they hold the same list and the same version.
     /// </summary>
-    public readonly struct ReadOnlyList<T> {
-        readonly List<T> list;
+    public readonly struct ReadOnlyList<T> : IEquatable<ReadOnlyList<T>> {
+        static readonly List<T> empty = new List<T>();
 
-        public ReadOnlyList(List<T> list) { 
-            this.list = list; 
+        readonly List<T> list;
+        readonly long version;
+
+        public ReadOnlyList(List<T> list) : this(list, 0) { }
+
+        /// <summary>
+        /// An owner that mutates the wrapped list should bump version each time it re-wraps,
+        /// so the new wrapper compares unequal to wrappers of earlier generations
+        /// </summary>
+        public ReadOnlyList(List<T> list, long version) {
+            this.list = list;
+            this.version = version;
         }
 
-        public List<T>.Enumerator GetEnumerator() => list.GetEnumerator();
+        public List<T>.Enumerator GetEnumerator() => (list ?? empty).GetEnumerator();
 
         public int Count => list?.Count ?? 0;
 
-        public T this[int index] => list[index];
+        public T this[int index] => (list ?? empty)[index];
+
+        /// <summary>Copies the current contents into storeIn (allocated if null). A stable snapshot of a possibly-live view</summary>
+        public List<T> ToList(List<T> storeIn = null) {
+            storeIn = storeIn ?? new List<T>(Count);
+            for (var i = 0; i < Count; i++) storeIn.Add(list[i]);
+            return storeIn;
+        }
+
+        public bool Equals(ReadOnlyList<T> other) => ReferenceEquals(list, other.list) && version == other.version;
+        public override bool Equals(object obj) => obj is ReadOnlyList<T> other && Equals(other);
+        public override int GetHashCode() => HashCode.Combine(list, version);
     }
 }

--- a/Spoke.Runtime/SpokeException.cs
+++ b/Spoke.Runtime/SpokeException.cs
@@ -17,9 +17,7 @@ namespace Spoke {
         public ReadOnlyList<SpokeRuntime.Frame> StackSnapshot => new(stackSnapshot);
 
         internal SpokeException(string msg, Exception inner) : base(msg, inner) {
-            foreach (var frame in SpokeRuntime.Frames) {
-                stackSnapshot.Add(frame);
-            }
+            SpokeRuntime.Frames.ToList(stackSnapshot);
             innerTrace = inner.ToString();
         }
 

--- a/Tests~/RuntimeTests/ReadOnlyListTests.cs
+++ b/Tests~/RuntimeTests/ReadOnlyListTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 
@@ -27,6 +28,82 @@ namespace Spoke.Tests {
         public void NullList_CountIsZero() {
             var rol = new ReadOnlyList<int>(null);
             Assert.AreEqual(0, rol.Count);
+        }
+
+        [Test]
+        public void NullList_EnumeratesZeroTimes() {
+            var iterations = 0;
+            foreach (var _ in default(ReadOnlyList<int>)) iterations++;
+            Assert.AreEqual(0, iterations);
+        }
+
+        [Test]
+        public void NullList_Indexer_ThrowsOutOfRange() {
+            var rol = default(ReadOnlyList<int>);
+            Assert.Throws<ArgumentOutOfRangeException>(() => _ = rol[0]);
+        }
+
+        [Test]
+        public void ToList_CopiesContents() {
+            var rol = new ReadOnlyList<int>(new List<int> { 1, 2, 3 });
+            var copy = rol.ToList();
+            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, copy);
+        }
+
+        [Test]
+        public void ToList_AppendsToStoreIn() {
+            var rol = new ReadOnlyList<int>(new List<int> { 2, 3 });
+            var storeIn = new List<int> { 1 };
+            var result = rol.ToList(storeIn);
+            Assert.AreSame(storeIn, result);
+            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, result);
+        }
+
+        [Test]
+        public void ToList_DefaultWrapper_ReturnsEmptyList() {
+            var copy = default(ReadOnlyList<int>).ToList();
+            Assert.IsEmpty(copy);
+        }
+
+        [Test]
+        public void Equals_SameListSameVersion_AreEqual() {
+            var inner = new List<int> { 1, 2 };
+            Assert.IsTrue(new ReadOnlyList<int>(inner, 3).Equals(new ReadOnlyList<int>(inner, 3)));
+        }
+
+        [Test]
+        public void Equals_SameListDifferentVersion_AreNotEqual() {
+            var inner = new List<int> { 1, 2 };
+            Assert.IsFalse(new ReadOnlyList<int>(inner, 0).Equals(new ReadOnlyList<int>(inner, 1)));
+        }
+
+        [Test]
+        public void Equals_DifferentListsSameContents_AreNotEqual() {
+            var a = new ReadOnlyList<int>(new List<int> { 1, 2 });
+            var b = new ReadOnlyList<int>(new List<int> { 1, 2 });
+            Assert.IsFalse(a.Equals(b));
+        }
+
+        [Test]
+        public void Equals_DefaultEqualsDefault() {
+            Assert.IsTrue(default(ReadOnlyList<int>).Equals(default));
+        }
+
+        [Test]
+        public void EqualityComparer_UsesVersionedEquality() {
+            // The path State<ReadOnlyList<T>>.Set dedups through
+            var inner = new List<int> { 1 };
+            var comparer = EqualityComparer<ReadOnlyList<int>>.Default;
+            Assert.IsTrue(comparer.Equals(new(inner, 5), new(inner, 5)));
+            Assert.IsFalse(comparer.Equals(new(inner, 5), new(inner, 6)));
+        }
+
+        [Test]
+        public void GetHashCode_EqualWrappers_HashEqual() {
+            var inner = new List<int> { 1, 2 };
+            Assert.AreEqual(
+                new ReadOnlyList<int>(inner, 2).GetHashCode(),
+                new ReadOnlyList<int>(inner, 2).GetHashCode());
         }
     }
 }


### PR DESCRIPTION
Some changes to `ReadOnlyList<T>` so it plays better as a value for reactive signals.
Now, it's possible to have an `ISignal<ReadOnlyList<T>>`, where the backing list can be mutated in place, instead of duplicating. So no allocations.

The `ReadOnlyList` is a view over the backing list with an additional `version` field. When the backing list changes, its owner can produce `ReadOnlyList`s with a bumped version number, so downstream effects/memos recognise it as a change, even though the `List` reference is the same.

This opens the door down the road for new reactive collection types, like a convenient reactive list or set.