### PR TITLE
Tighten ReadOnlyList

### DIFF
--- a/Examples/05_BaseDefence/Scripts/Spatial/CollisionWorld.cs
+++ b/Examples/05_BaseDefence/Scripts/Spatial/CollisionWorld.cs
@@ -70,9 +70,10 @@ namespace Spoke.Examples.BaseDefence {
         /// <summary>Syncs collider/sensor positions, calculates overlaps, and publishes Overlaps where they changed</summary>
         public void Tick() => SpokeRuntime.Batch(step);
 
-        /// <summary>One-off immediate lookup of colliders overlapping area.</summary>
+        /// <summary>One-off immediate lookup of colliders overlapping area, stored in storeIn (cleared first; allocated if null).</summary>
         public List<ICollider<T>> Query(Circle area, List<ICollider<T>> storeIn = null) {
-            storeIn = storeIn ?? new List<ICollider<T>>();
+            if (storeIn == null) storeIn = new List<ICollider<T>>();
+            else storeIn.Clear();
             foreach (var body in Broadphase(area))
                 if (body.detectable && area.Overlaps(body.Circle))
                     storeIn.Add(body);
@@ -157,6 +158,7 @@ namespace Spoke.Examples.BaseDefence {
                 world.bodies.Remove(this);
                 world.Remove(this);
                 overlaps.Clear();
+                overlapsState.Set(new ReadOnlyList<ICollider<T>>(overlaps, ++version));
                 world = null;
             }
 

--- a/Spoke.Runtime/ReadOnlyList.cs
+++ b/Spoke.Runtime/ReadOnlyList.cs
@@ -32,9 +32,12 @@ namespace Spoke {
 
         public T this[int index] => (list ?? empty)[index];
 
-        /// <summary>Copies the current contents into storeIn (allocated if null). A stable snapshot of a possibly-live view</summary>
+        public bool Contains(T item) => (list ?? empty).Contains(item);
+
+        /// <summary>Copies the current contents into storeIn (cleared first; allocated if null). A stable snapshot of a possibly-live view</summary>
         public List<T> ToList(List<T> storeIn = null) {
-            storeIn = storeIn ?? new List<T>(Count);
+            if (storeIn == null) storeIn = new List<T>(Count);
+            else storeIn.Clear();
             for (var i = 0; i < Count; i++) storeIn.Add(list[i]);
             return storeIn;
         }

--- a/Tests~/RuntimeTests/ReadOnlyListTests.cs
+++ b/Tests~/RuntimeTests/ReadOnlyListTests.cs
@@ -44,6 +44,18 @@ namespace Spoke.Tests {
         }
 
         [Test]
+        public void Contains_FindsItem() {
+            var rol = new ReadOnlyList<int>(new List<int> { 1, 2, 3 });
+            Assert.IsTrue(rol.Contains(2));
+            Assert.IsFalse(rol.Contains(4));
+        }
+
+        [Test]
+        public void NullList_ContainsIsFalse() {
+            Assert.IsFalse(default(ReadOnlyList<int>).Contains(0));
+        }
+
+        [Test]
         public void ToList_CopiesContents() {
             var rol = new ReadOnlyList<int>(new List<int> { 1, 2, 3 });
             var copy = rol.ToList();
@@ -51,12 +63,12 @@ namespace Spoke.Tests {
         }
 
         [Test]
-        public void ToList_AppendsToStoreIn() {
+        public void ToList_ClearsStoreIn() {
             var rol = new ReadOnlyList<int>(new List<int> { 2, 3 });
             var storeIn = new List<int> { 1 };
             var result = rol.ToList(storeIn);
             Assert.AreSame(storeIn, result);
-            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, result);
+            CollectionAssert.AreEqual(new[] { 2, 3 }, result);
         }
 
         [Test]


### PR DESCRIPTION
Tightens some semantics for `ReadOnlyList` that were missed in the last PR

- `ReadOnlyList.Contains` is now implemented
- `ReadOnlyList.ToList` clears the input list if one is provided
- Fixed a small gap (probably inert) in the CollisionWorld version bump logic